### PR TITLE
Update capistrano to use -knob.yml

### DIFF
--- a/system/capistrano-support/lib/torquebox/capistrano/recipes.rb
+++ b/system/capistrano-support/lib/torquebox/capistrano/recipes.rb
@@ -113,9 +113,7 @@ Capistrano::Configuration.instance.load do
     
         dd_str = YAML.dump_stream( dd )
 
-        dd_suffix = is_rails? ? 'rails' : 'rack'
-    
-        dd_file = "#{jboss_home}/server/#{jboss_config}/deploy/#{application}-#{dd_suffix}.yml"
+        dd_file = "#{jboss_home}/server/#{jboss_config}/deploy/#{application}-knob.yml"
         dd_tmp_file = "#{dd_file}.tmp"
         
         cmd =  "cat /dev/null > #{dd_tmp_file}"


### PR DESCRIPTION
I have no idea where tests for this is. So.. no tests. Yell at me in IRC about it.

Simple fix, but syncs up the cap support with the recent switch to app-knob.yml descriptor file.
