### PR TITLE
Update arjdbc template

### DIFF
--- a/system/rake-support/share/rails-template.rb
+++ b/system/rake-support/share/rails-template.rb
@@ -1,10 +1,10 @@
 
 if ( Rails::VERSION::MAJOR == 2 )
-  gem "activerecord-jdbc-adapter", :lib => "jdbc_adapter"
+  gem "activerecord-jdbc-adapter", :lib => "arjdbc"
 else
   text = File.read 'Gemfile'
   File.open('Gemfile', 'w') {|f| f << text.gsub(/^(gem 'sqlite3)/, '# \1') }
-  gem "activerecord-jdbc-adapter", "0.9.7", :require => "jdbc_adapter"
+  gem "activerecord-jdbc-adapter", :require => "arjdbc"
   gem "jdbc-sqlite3"
   gem "jruby-openssl"
 end


### PR DESCRIPTION
This is an untested change, since I didn't see any tests regarding the rails template.

It does however match my working development project, using a CR Dev version of Torquebox as of a few days ago.  

This removes the warning about: DEPRECATED: require 'arjdbc' instead of 'jdbc_adapter'.
