### PR TITLE
Update rails version numbers

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -235,8 +235,8 @@
     <version.snakeyaml>1.5</version.snakeyaml>
     <version.rack>1.1.0</version.rack>
 
-    <version.rails2>2.3.10</version.rails2>
-    <version.rails3>3.0.3</version.rails3>
+    <version.rails2>2.3.11</version.rails2>
+    <version.rails3>3.0.5</version.rails3>
 
     <version.ar.jdbc>0.9.7</version.ar.jdbc>
     <version.ar.sqlite3>0.9.7</version.ar.sqlite3>


### PR DESCRIPTION
Since I'm not super familiar with the build environment, I hope this doesn't screw up anything.  Just want to reflect the newest versions of Rails in the documentation.

Specifically, section 4.2 of the docs (http://torquebox.org/documentation/DEV/rails.html) is out of date currently.
