### PR TITLE
Specify version for wagon-webdav-jackrabbit plugin to make NetBeans happy 

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -324,6 +324,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-webdav-jackrabbit</artifactId>
+        <version>1.0-beta-7</version>
       </extension>
     </extensions>
 


### PR DESCRIPTION
Added version to wagon-webdav-jackrabbit plugin to make NetBeans a happy camper. Currently set to 1.0-beta7 as it's the most up-to-date one I could find on the configured repositories.
