### PR TITLE
Allows rake torquebox:run to work again.

### DIFF
--- a/system/rake-support/lib/torquebox/rake/tasks/server.rb
+++ b/system/rake-support/lib/torquebox/rake/tasks/server.rb
@@ -28,7 +28,7 @@ namespace :torquebox do
 
   desc "Run TorqueBox server"
   task :run=>[ :check ] do
-    TorqueBox::RakeUtils.run_server
+    TorqueBox::DeployUtils.run_server
   end
 
 end


### PR DESCRIPTION
Call DeployUtils.run_server instead of RakeUtils.run_server (which is gone)
