### PR TITLE
Added assembly/share to torquebox-server gem

### DIFF
--- a/build/server/pom.xml
+++ b/build/server/pom.xml
@@ -80,7 +80,7 @@
         <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
-            <id>copy-assembly-for-gem</id>
+            <id>copy-assembly-jboss-for-gem</id>
             <phase>process-sources</phase>
             <goals>
               <goal>copy-resources</goal>
@@ -94,6 +94,21 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <id>copy-assembly-share-for-gem</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/torquebox-server/share</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${basedir}/../assembly/target/stage/torquebox/share</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -102,6 +117,7 @@
         <configuration>
           <jrubyJvmArgs>-Xmx1024m</jrubyJvmArgs>
           <extraFiles>jboss/**/*</extraFiles>
+          <extraFiles>share/**/*</extraFiles>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
I added the share directory to the torquebox-server gem so folks can get at share/rails/template.rb

Its not exactly clear to me how to get at it, though. I see the "torquebox env" command, but I'm not sure of the best way to use that in a "rails new" command (but i suck at the cmd line).
