### PR TITLE
removed coffeescript from TORQUE-615 integration test

### DIFF
--- a/integration-tests/apps/rails3.1/sprockets-2.1/app/assets/javascripts/home.js.coffee
+++ b/integration-tests/apps/rails3.1/sprockets-2.1/app/assets/javascripts/home.js.coffee
@@ -1,3 +1,0 @@
-# Place all the behaviors and hooks related to the matching controller here.
-# All this logic will automatically be available in application.js.
-# You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/


### PR DESCRIPTION
I removed the coffeescript from the TORQUE-615 test, since therubyrhino (used in integration testing only) has issues when processing coffeescript. 
