### PR TITLE
Fix for TORQUE-626

### DIFF
--- a/gems/vfs/lib/torquebox/vfs/ext/io.rb
+++ b/gems/vfs/lib/torquebox/vfs/ext/io.rb
@@ -89,7 +89,7 @@ class IO
       virtual_file = org.jboss.vfs.VFS.child( fd )
 
       if ( ! create && ! virtual_file.exists )
-        raise Errno::ENOENT
+        raise Errno::ENOENT, fd
       end
 
       if ( read && ! write )

--- a/gems/vfs/spec/io_spec.rb
+++ b/gems/vfs/spec/io_spec.rb
@@ -25,6 +25,14 @@ describe "IO extensions for VFS" do
         prefix = vfs_path( prefix ) if vfs_style == :vfs
 
         describe 'read' do
+        
+          it "should raise a proper exception if file not found" do
+            begin
+              content = IO.read( "#{prefix}/joey/jo/jo/junior.shabadoo" )
+            rescue => ex
+              ex.message.should include "joey/jo/jo/junior.shabadoo"
+            end
+          end
           
           it "should allow reading of regular files" do
             content = IO.read( "#{prefix}/home/larry/file1.txt" ).chomp


### PR DESCRIPTION
This pull request contains a fix for TORQUE-626, which provides a better error message for any missing file errors from Rails (such as database.yml).
