### PR TITLE
added docs, torquebox-configure support for TORQUE-627

### DIFF
--- a/docs/en-US/src/main/docbook/deployment-descriptors.xml
+++ b/docs/en-US/src/main/docbook/deployment-descriptors.xml
@@ -434,6 +434,21 @@ end</programlisting></para>
 
               <entry><parameter>false</parameter></entry>
             </row>
+
+            <row>
+              <entry><varname>profile_api</varname></entry>
+              <entry>A value of <emphasis>true</emphasis> enables JRuby's 
+              profiler instrumentation, which allows you to obtain performance 
+              information on a given block of ruby code.
+
+              <para>For more information, check out 
+              <ulink url="http://danlucraft.com/blog/2011/03/built-in-profiler-in-jruby-1.6/">How to Use the New JRuby Profiler</ulink>
+              </para>
+              </entry>
+
+              <entry><parameter>false</parameter></entry> 
+            </row>
+
           </tbody>
         </tgroup>
       </table>
@@ -443,7 +458,8 @@ end</programlisting></para>
   version: 1.9
   compile_mode: off
   debug: false
-  interactive: true</programlisting></para>
+  interactive: true
+  profile_api: true</programlisting></para>
         </informalexample> And via the DSL: <informalexample>
           <para><programlisting>TorqueBox.configure do
   ruby do
@@ -451,6 +467,7 @@ end</programlisting></para>
     compile_mode "off"
     debug false
     interactive true
+    profile_api true
   end
 end</programlisting></para>
         </informalexample></para>
@@ -500,6 +517,7 @@ end</programlisting></para>
         <para>For example, in YAML: <informalexample>
             <para><programlisting>environment:
   RAILS_ENV: production</programlisting></para>
+
           </informalexample> And via the DSL: <informalexample>
             <para><programlisting>TorqueBox.configure do 
   environment do

--- a/gems/configure/lib/torquebox/configuration/global.rb
+++ b/gems/configure/lib/torquebox/configuration/global.rb
@@ -82,7 +82,8 @@ module TorqueBox
                                                                      { :compile_mode => [:force, :jit, :off,
                                                                                          'force', 'jit', 'off'] },
                                                                      { :debug => [true, false] },
-                                                                     { :interactive => [true, false] }
+                                                                     { :interactive => [true, false] },
+                                                                     { :profile_api => [true, false] }
                                                                     ]
                                                      }),
           :service     => ThingWithOptionsEntry.with_settings(:discrete => true,

--- a/gems/configure/spec/global_spec.rb
+++ b/gems/configure/spec/global_spec.rb
@@ -143,12 +143,13 @@ describe "TorqueBox.configure using the GlobalConfiguration" do
     it_should_behave_like 'options'
 
     it_should_not_allow_invalid_options { ruby :foo => :bar }
-    it_should_allow_valid_options { ruby :version => '1.9', :compile_mode => :jit, :debug => true, :interactive => true }
+    it_should_allow_valid_options { ruby :version => '1.9', :compile_mode => :jit, :debug => true, :interactive => true, :profile_api => true }
 
     it_should_not_allow_invalid_option_values { ruby :version => '2' }
     it_should_not_allow_invalid_option_values { ruby :compile_mode => :bacon }
     it_should_not_allow_invalid_option_values { ruby :debug => :sure }
     it_should_not_allow_invalid_option_values { ruby :interactive => :sure }
+    it_should_not_allow_invalid_option_values { ruby :profile_api => :goforit }
     it_should_allow_valid_option_values { ruby :version => '1.8', :compile_mode => :jit }
   end
 


### PR DESCRIPTION
This pull request adds documentation and torquebox-configure support for the profile_api ruby configuration option (TORQUE-627).
