### PR TITLE
Guard against referencing Infinispan-specific objects outside of TorqueBox

### DIFF
--- a/gems/cache/lib/cache.rb
+++ b/gems/cache/lib/cache.rb
@@ -94,6 +94,7 @@ module TorqueBox
       end
 
       def initialize(opts = {})
+        return nothing unless INFINISPAN_AVAILABLE
         @options = opts
         options[:transaction_mode] = :transactional unless options.has_key?( :transaction_mode )
         options[:locking_mode] ||= :optimistic if (transactional? && !options.has_key?( :locking_mode ))


### PR DESCRIPTION
Be explicit about the fact that a dummy object is returned in that case.

RE:  TORQUE-635
