### PR TITLE
TORQUE-684: Add support for startup command-options on upstart:install

### DIFF
--- a/gems/rake-support/share/init/torquebox.conf.erb
+++ b/gems/rake-support/share/init/torquebox.conf.erb
@@ -1,0 +1,14 @@
+description "This is an upstart job file for torquebox"
+
+pre-start script
+bash << "EOF"
+  mkdir -p /var/log/torquebox
+  chown -R torquebox /var/log/torquebox
+EOF
+end script
+
+start on started network-services
+stop on stopped network-services
+respawn
+
+exec su - torquebox -c '/opt/torquebox/jboss/bin/standalone.sh <%= server_opts %> >> /var/log/torquebox/torquebox.log 2>&1'

--- a/gems/rake-support/spec/upstart_spec.rb
+++ b/gems/rake-support/spec/upstart_spec.rb
@@ -1,0 +1,18 @@
+require 'torquebox/upstart'
+
+describe TorqueBox::Upstart do
+
+  describe ".copy_init_script" do
+    it "should not use the template" do
+      # need fakefs or something
+    end
+  end
+
+  describe ".process_init_template" do
+    it "should substitute the values" do
+      ENV["TORQUEBOX_HOME"] = File.expand_path("..", File.dirname(__FILE__))
+      r = TorqueBox::Upstart.process_init_template("--server-config=standalone-ha.xml")
+      r.should include("--server-config=standalone-ha.xml")
+    end
+  end
+end


### PR DESCRIPTION
Created a torquebox.conf.erb that is used if server_opts is set. Added a spec for the templating method.
-  I left torquebox.conf in place (seems useful)
-  I used server_opts (case insensitive), but torquebox_opts might be better as Ben suggested in another disscussion.
-  There's no spec for the copy_init_script method, it would need fakefs or something.

let me know if I should make some changes.
