### PR TITLE
minor fix to ms x minutes bug

### DIFF
--- a/modules/web/src/main/java/org/torquebox/web/rack/processors/WebYamlParsingProcessor.java
+++ b/modules/web/src/main/java/org/torquebox/web/rack/processors/WebYamlParsingProcessor.java
@@ -78,12 +78,12 @@ public class WebYamlParsingProcessor extends AbstractSplitYamlParsingProcessor {
             } else if (timeoutStr.endsWith( "h" )) {
                 timeUnit = TimeUnit.HOURS;
                 timeoutStr = timeoutStr.substring( 0, timeoutStr.length() - 1 );
-            } else if (timeoutStr.endsWith( "s" )) {
-                timeUnit = TimeUnit.SECONDS;
-                timeoutStr = timeoutStr.substring( 0, timeoutStr.length() - 1 );
             } else if (timeoutStr.endsWith( "ms" )) {
                 timeUnit = TimeUnit.MILLISECONDS;
                 timeoutStr = timeoutStr.substring( 0, timeoutStr.length() - 2 );
+            } else if (timeoutStr.endsWith("s")) {
+                timeUnit = TimeUnit.SECONDS;
+                timeoutStr = timeoutStr.substring(0, timeoutStr.length() - 1);
             }
             long timeout = Long.parseLong( timeoutStr.trim() );
             rackAppMetaData.setSessionTimeout( timeout, timeUnit );


### PR DESCRIPTION
Morning, during my development with quartz I found a minor bug in session-timeout units. When you switch from minutes to ms, WebYamlParsingProcessor fails.

To reproduce the error, just change at 2x-dev the file valid-web.yml with:

web:
  host: foobar.com
  context: /tacos
  session-timeout: 10 ms 
