### PR TITLE
const_missing: require all files w/ matching name

### DIFF
--- a/gems/messaging/lib/torquebox/messaging/const_missing.rb
+++ b/gems/messaging/lib/torquebox/messaging/const_missing.rb
@@ -20,7 +20,7 @@ unless defined?(ActiveSupport)
   
   def Object.const_missing(name)
     file = org.torquebox.core.util.StringUtils.underscore(name)
-    require file
+    Dir["./**/#{file}.rb"].each { |f| require f }
     result = const_get(name)
     return result if result
     raise "Class not found: #{name}"


### PR DESCRIPTION
What about this as a quick fix for TORQUE-698? Untested though.. 

https://issues.jboss.org/browse/TORQUE-698
