### PR TITLE
Opt app root out of annonatation index (TORQUE-687)

### DIFF
--- a/modules/core/src/main/java/org/torquebox/core/app/processors/AppKnobYamlParsingProcessor.java
+++ b/modules/core/src/main/java/org/torquebox/core/app/processors/AppKnobYamlParsingProcessor.java
@@ -77,7 +77,7 @@ public class AppKnobYamlParsingProcessor extends AbstractParsingProcessor {
                 } else {
                     appRoot = new ResourceRoot( root, null );
                 }
-                unit.putAttachment( Attachments.INDEX_RESOURCE_ROOT, false );
+                appRoot.putAttachment( Attachments.INDEX_RESOURCE_ROOT, false );
                 unit.putAttachment( Attachments.DEPLOYMENT_ROOT, appRoot );
             }
             else {


### PR DESCRIPTION
Apps with large numbers of user uploaded assets under /public can timeout when deploying due to resource root scanner recursing through a huge number of directories.
