### PR TITLE
Fixing typo in Capistrano recipe that was causing default jboss_control_...

### DIFF
--- a/gems/capistrano-support/lib/torquebox/capistrano/recipes.rb
+++ b/gems/capistrano-support/lib/torquebox/capistrano/recipes.rb
@@ -68,7 +68,7 @@ module Capistrano
         set( :jruby_bin,           lambda{ "#{jruby_home}/bin/jruby #{jruby_opts}" } ) unless exists?( :jruby_bin )
 
         set( :jboss_home,          lambda{ "#{torquebox_home}/jboss" } ) unless exists?( :jboss_home )
-        set( :jboss_control_style, :initid ) unless exists?( :jboss_control_style )
+        set( :jboss_control_style, :initd ) unless exists?( :jboss_control_style )
         set( :jboss_init_script,   '/etc/init.d/jboss-as-standalone' ) unless exists?( :jboss_init_script )
         set( :jboss_bind_address,  '0.0.0.0' ) unless exists?( :jboss_bind_address )
 


### PR DESCRIPTION
...style to be set improperly by default causing deploy tasks to silently not work.
