### PR TITLE
Suggestion to change deploy:restart deploy:stop deploy:start behaviour 

### DIFF
--- a/gems/capistrano-support/lib/torquebox/capistrano/recipes.rb
+++ b/gems/capistrano-support/lib/torquebox/capistrano/recipes.rb
@@ -83,41 +83,46 @@ module Capistrano
             update
           end
         
-          desc "Start TorqueBox Server"
-          task :start do
-            puts "Starting TorqueBox AS"
-            case ( jboss_control_style )
-              when :initd
-                run "#{jboss_init_script} start"
-              when :binscripts
-                run "nohup #{jboss_home}/bin/standalone.sh -b #{jboss_bind_address} < /dev/null > /dev/null 2>&1 &"
-            end
-          end
-        
-          desc "Stop TorqueBox Server"
-          task :stop do
-            puts "Stopping TorqueBox AS"
-            case ( jboss_control_style )
-              when :initd
-                run "JBOSS_HOME=#{jboss_home} #{jboss_init_script} stop"
-              when :binscripts
-                run "#{jboss_home}/bin/jboss-cli.sh --connect :shutdown"
-            end
-          end
-        
-          desc "Restart TorqueBox Server"
+          desc "Restart Application"
           task :restart do
-            case ( jboss_control_style )
-              when :initd
-                puts "Restarting TorqueBox AS"
-                puts "JBOSS_HOME=#{jboss_home} #{jboss_init_script} restart"
-              when :binscripts
-                run "JBOSS_HOME=#{jboss_home} #{jboss_init_script} stop"
-                run "nohup #{jboss_home}/bin/standalone.sh -bpublic=#{jboss_bind_address} < /dev/null > /dev/null 2>&1 &"
-            end
+            run "touch #{jboss_home}/standalone/deployments/#{application}-knob.yml.dodeploy"
           end
-        
+ 
           namespace :torquebox do
+
+            desc "Start TorqueBox Server"
+            task :start do
+              puts "Starting TorqueBox AS"
+              case ( jboss_control_style )
+                when :initd
+                  run "#{jboss_init_script} start"
+                when :binscripts
+                  run "nohup #{jboss_home}/bin/standalone.sh -b #{jboss_bind_address} < /dev/null > /dev/null 2>&1 &"
+              end
+            end
+        
+            desc "Stop TorqueBox Server"
+            task :stop do
+              puts "Stopping TorqueBox AS"
+              case ( jboss_control_style )
+                when :initd
+                  run "JBOSS_HOME=#{jboss_home} #{jboss_init_script} stop"
+                when :binscripts
+                  run "#{jboss_home}/bin/jboss-cli.sh --connect :shutdown"
+              end
+            end
+        
+            desc "Restart TorqueBox Server"
+            task :restart do
+              case ( jboss_control_style )
+                when :initd
+                  puts "Restarting TorqueBox AS"
+                  puts "JBOSS_HOME=#{jboss_home} #{jboss_init_script} restart"
+                when :binscripts
+                  run "JBOSS_HOME=#{jboss_home} #{jboss_init_script} stop"
+                  run "nohup #{jboss_home}/bin/standalone.sh -bpublic=#{jboss_bind_address} < /dev/null > /dev/null 2>&1 &"
+              end
+            end
 
             task :info do
               puts "torquebox_home.....#{torquebox_home}"
@@ -147,7 +152,6 @@ module Capistrano
               end
               cmd += " && echo '' >> #{dd_file}"
               run cmd
-              run "touch #{dd_file}.dodeploy"
             end
           end
 


### PR DESCRIPTION
Currently deploy:restart restarts TB instead of just touching dodeploy file. Moved deploy:start deploy:stop deploy:start to deploy:torquebox namespace, because it's really TB things. Implemented deploy:restart that just touches dodeploy file
