### PR TITLE
Added a respond_to method to match method_missing

### DIFF
--- a/gems/messaging/lib/torquebox/messaging/message.rb
+++ b/gems/messaging/lib/torquebox/messaging/message.rb
@@ -76,6 +76,10 @@ module TorqueBox
         @jms_message.send(*args)
       end
 
+      def respond_to?(symbol, include_private = false)
+        super || @jms_message.respond_to?(symbol, include_private)
+      end
+
       class << self
         alias :__new__ :new
 


### PR DESCRIPTION
TorqueBox::Messaging::TextMessage implements method_missing which delegates to @jms_message. However, it does not implement respond_to?. Thus, code like: message.respond_to?(:text) returns false whereas the object would respond to message.text. This small patch tries to correct it. 

Caution: I did not implement a test for it.

A JIRA issue will be opened.
