### PR TITLE
explicitly rescue NameError when loading logger to fix [TORQUE-527]

### DIFF
--- a/gems/core/lib/torquebox/logger.rb
+++ b/gems/core/lib/torquebox/logger.rb
@@ -38,7 +38,7 @@ module TorqueBox
 
   begin
     org.jboss.logging::Logger
-  rescue
+  rescue ::NameError
     Logger = FallbackLogger
     return
   end


### PR DESCRIPTION
I couldn't figure out a good way to write a spec for this (aside from completely munging the classpath).  If it's important, I'll keep experimenting with it.
