### PR TITLE
When creating an archive, each filename is now surrounded with quotes

### DIFF
--- a/gems/rake-support/lib/torquebox/deploy_utils.rb
+++ b/gems/rake-support/lib/torquebox/deploy_utils.rb
@@ -184,7 +184,7 @@ module TorqueBox
           include_files = []
           Dir[ "**/**", ".bundle/**/**" ].each do |entry|
             unless File.directory?(entry) || skip_files.any? {|regex| entry.match(regex)}
-              include_files << entry 
+              include_files << '"' + entry.to_s + '"'
             end
           end
 


### PR DESCRIPTION
This ensures support for folders/files with spaces in their names.
