### PR TITLE
capistrano-support: work without jruby_opts or app_ruby_version set

### DIFF
--- a/gems/capistrano-support/lib/torquebox/capistrano/recipes.rb
+++ b/gems/capistrano-support/lib/torquebox/capistrano/recipes.rb
@@ -67,7 +67,7 @@ module Capistrano
         if exists?( :app_ruby_version ) && !exists?( :jruby_opts )
           set( :jruby_opts,          lambda{ "--#{app_ruby_version}" } )
         end
-        set( :jruby_bin,           lambda{ "#{jruby_home}/bin/jruby #{jruby_opts}" } ) unless exists?( :jruby_bin )
+        set( :jruby_bin,           lambda{ "#{jruby_home}/bin/jruby #{jruby_opts if exists?( :jruby_opts )}" } ) unless exists?( :jruby_bin )
 
         set( :jboss_home,          lambda{ "#{torquebox_home}/jboss" } ) unless exists?( :jboss_home )
         set( :jboss_control_style, :initd ) unless exists?( :jboss_control_style )

--- a/gems/capistrano-support/spec/recipes_spec.rb
+++ b/gems/capistrano-support/spec/recipes_spec.rb
@@ -29,6 +29,13 @@ describe Capistrano::TorqueBox, "loaded into a configuration" do
     @configuration.exists?( :app_ruby_version ).should be_false
   end
 
+  it "should allow setting neither app_ruby_version nor jruby_opts" do
+    Capistrano::TorqueBox.load_into(@configuration)
+    @configuration.exists?( :app_ruby_version ).should be_false
+    @configuration.exists?( :jruby_opts ).should be_false
+    expect { @configuration.fetch( :jruby_bin ) }.not_to raise_error
+  end
+
   it "should allow default 1.9 override for app_ruby_version" do
     @configuration.set( :app_ruby_version, 1.9 )
     Capistrano::TorqueBox.load_into(@configuration)


### PR DESCRIPTION
I was getting this error in my app because I wasn't setting app_ruby_version or jruby_opts

The test I added would fail when trying to read jruby_bin before I made the fix:

```
  1) Capistrano::TorqueBox loaded into a configuration should allow setting neither app_ruby_version nor jruby_opts
     Failure/Error: expect { @configuration.fetch( :jruby_bin ) }.not_to raise_error
       expected no Exception, got #<NameError: undefined local variable or method `jruby_opts' for #<Capistrano::Configuration:0x302b2c81>>
```
