### PR TITLE
Make Torquebox::Logger compatible with Rack::CommonLogger

### DIFF
--- a/gems/core/lib/torquebox/logger.rb
+++ b/gems/core/lib/torquebox/logger.rb
@@ -82,6 +82,12 @@ module TorqueBox
       self.send(method, *args, &block)
     end
 
+    # Make the Logger compatible with Rack::CommonLogger
+    #
+    def write(message)
+      info message.strip
+    end
+
     private
 
     def params_for_logger(args, block)


### PR DESCRIPTION
This patch will allow Sinatra users to use Torquebox::Logger together with Rack::CommonLogger like:

```
# config.ru:
require './myapp'

use Rack:::CommonLogger, Torquebox::Logger.new

run MyApp
```

The Torquebox console will then output:

21:11:40,669 INFO  [org.jboss.as.server](DeploymentScanner-threads - 2) JBAS018559: Deployed "jsinatra-knob.yml"
21:11:44,802 INFO  [jsinatra](http-localhost.localdomain/127.0.0.1:8080-1) 127.0.0.1 - - [17/Nov/2012 21:11:44] "GET / " 200 12 0.5610
21:11:45,401 INFO  [jsinatra](http-localhost.localdomain/127.0.0.1:8080-1) 127.0.0.1 - - [17/Nov/2012 21:11:45] "GET / " 200 12 0.0070
21:11:46,062 INFO  [jsinatra](http-localhost.localdomain/127.0.0.1:8080-1) 127.0.0.1 - - [17/Nov/2012 21:11:46] "GET / " 200 12 0.0070
