### PR TITLE
[TORQUE-986] description option not allowed in job section of DSL config

### DIFF
--- a/gems/configure/lib/torquebox/configuration/global.rb
+++ b/gems/configure/lib/torquebox/configuration/global.rb
@@ -56,6 +56,7 @@ module TorqueBox
                                                                 :optional => [
                                                                               :config,
                                                                               :name,
+                                                                              :description,
                                                                               { :singleton => [true, false] }
                                                                              ]
                                                               }),

--- a/gems/configure/spec/global_spec.rb
+++ b/gems/configure/spec/global_spec.rb
@@ -335,7 +335,7 @@ describe "TorqueBox.configure using the GlobalConfiguration" do
     it_should_behave_like 'a thing with options'
 
     it_should_not_allow_invalid_options { job 'AClass', :foo => :bar }
-    it_should_allow_valid_options { job 'AClass', :config => '', :singleton => true, :name => '' , :cron => '234'}
+    it_should_allow_valid_options { job 'AClass', :config => '', :singleton => true, :name => '' , :cron => '234', :description => 'A description'}
 
     it_should_not_allow_invalid_option_values { job 'AClass', :singleton => :bacon }
     it_should_allow_valid_option_values { job 'AClass', :singleton => false, :cron => '234' }
@@ -357,6 +357,15 @@ describe "TorqueBox.configure using the GlobalConfiguration" do
       
       config['<root>']['job'].should == [['One::AJob', { :cron => '1234' }],
                                          ['Two::AJob', { :cron => '1234' }]]
+    end
+
+    # https://issues.jboss.org/browse/TORQUE-986
+    it "should allow job description" do
+      config = TorqueBox.configure do
+        job 'AJob', :cron => '1234', :description => 'A description'
+      end
+
+      config['<root>']['job'].should == [['AJob', { :cron => '1234', :description => 'A description' }]]
     end
 
     it "should allow jobs as constants" do

--- a/integration-tests/apps/alacarte/runtime_initialization/torquebox.rb
+++ b/integration-tests/apps/alacarte/runtime_initialization/torquebox.rb
@@ -11,5 +11,7 @@ TorqueBox.configure do
   service SimpleService 
   job SimpleJob do
     cron '*/1 * * * * ?'
+    # https://issues.jboss.org/browse/TORQUE-986
+    description 'A description for a job'
   end
 end


### PR DESCRIPTION
This fixes the issue. Added a unit test and modified one integration test to check this.

Additionally made sure the description is set by running this app:

torquebox.rb:

``` ruby
TorqueBox.configure do
  job Dummy do
    cron '*/10 * * * * ?'
    name 'dummy'
    description 'A description for a job'
  end
end
```

dummy.rb:

``` ruby
class Dummy
  def run
    job = TorqueBox::ScheduledJob.lookup('dummy')
    puts job.name
    puts job.description
    puts "Dummy job executed"
  end
end
```
