### PR TITLE
[TORQUE-790] Scheduled message delivery

### DIFF
--- a/docs/manual/en-US/src/main/docbook/messaging.xml
+++ b/docs/manual/en-US/src/main/docbook/messaging.xml
@@ -610,6 +610,20 @@ queue.publish "Some message"</programlisting></para>
               </row>
 
               <row>
+                <entry><parameter>:scheduled</parameter></entry>
+
+                <entry>nil</entry>
+
+                <entry>By default a message will be delivered to the queue or topic
+                immediately. You can delay the delivery by using the
+                <parameter>:scheduled</parameter>. The specified value must be a
+                <ulink url="http://www.ruby-doc.org/core/Time.html">Time</ulink>
+                object containing the time it should be delivered. Please note that
+                scheduled messages will be delivered only to the consumers connected
+                at the time of publishing the message.</entry>
+              </row>
+
+              <row>
                 <entry><parameter>:tx</parameter></entry>
 
                 <entry>true</entry>

--- a/gems/messaging/lib/torquebox/messaging/message.rb
+++ b/gems/messaging/lib/torquebox/messaging/message.rb
@@ -57,17 +57,17 @@ module TorqueBox
       end
 
       def populate_message_properties(properties)
-        return if properties.nil?
+        return if properties.nil? or properties.empty?
         properties.each do |key, value|
           case value
-          when Integer
-            @jms_message.set_long_property(key.to_s, value)
-          when Float
-            @jms_message.set_double_property(key.to_s, value)
-          when TrueClass, FalseClass
-            @jms_message.set_boolean_property(key.to_s, value)
-          else
-            @jms_message.set_string_property(key.to_s, value.to_s)
+            when Integer
+              @jms_message.set_long_property(key.to_s, value)
+            when Float
+              @jms_message.set_double_property(key.to_s, value)
+            when TrueClass, FalseClass
+              @jms_message.set_boolean_property(key.to_s, value)
+            else
+              @jms_message.set_string_property(key.to_s, value.to_s)
           end
         end
       end

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -378,7 +378,21 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>activesupport</artifactId>
+      <version>${version.rails3}</version>
+      <type>gem</type>
+      <scope>test</scope>
+    </dependency>
 
+    <dependency>
+      <groupId>rubygems</groupId>
+      <artifactId>i18n</artifactId>
+      <version>0.5.0</version>
+      <type>gem</type>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/TORQUE-790, example usage:

``` ruby
# Send a message 2 sec later
queue.publish "wassup", :scheduled => Time.now.to_i * 1000 + 2 * 1000

# Send a message 5 sec later and receive the response
queue.publish_and_receive "wassup", :timeout => 1000, :scheduled => Time.now.to_i * 1000 + 5 * 1000
```
