### PR TITLE
[TORQUE-999] 'timeout' option not allowed in job section of DSL configuration

### DIFF
--- a/gems/configure/lib/torquebox/configuration/global.rb
+++ b/gems/configure/lib/torquebox/configuration/global.rb
@@ -57,6 +57,7 @@ module TorqueBox
                                                                               :config,
                                                                               :name,
                                                                               :description,
+                                                                              :timeout,
                                                                               { :singleton => [true, false] }
                                                                              ]
                                                               }),

--- a/gems/configure/spec/global_spec.rb
+++ b/gems/configure/spec/global_spec.rb
@@ -368,6 +368,15 @@ describe "TorqueBox.configure using the GlobalConfiguration" do
       config['<root>']['job'].should == [['AJob', { :cron => '1234', :description => 'A description' }]]
     end
 
+    # https://issues.jboss.org/browse/TORQUE-999
+    it "should allow job timeout" do
+      config = TorqueBox.configure do
+        job 'AJob', :cron => '1234', :timeout => '30s'
+      end
+
+      config['<root>']['job'].should == [['AJob', { :cron => '1234', :timeout => '30s' }]]
+    end
+
     it "should allow jobs as constants" do
       config = TorqueBox.configure do |cfg|
         cfg.instance_eval("job JobX, :cron => '1234'")

--- a/integration-tests/apps/alacarte/runtime_initialization/torquebox.rb
+++ b/integration-tests/apps/alacarte/runtime_initialization/torquebox.rb
@@ -13,5 +13,7 @@ TorqueBox.configure do
     cron '*/1 * * * * ?'
     # https://issues.jboss.org/browse/TORQUE-986
     description 'A description for a job'
+    # https://issues.jboss.org/browse/TORQUE-999
+    timeout '30s'
   end
 end


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/TORQUE-999
