### PR TITLE
Fix for TORQUE-941

### DIFF
--- a/gems/cache/lib/cache.rb
+++ b/gems/cache/lib/cache.rb
@@ -147,7 +147,7 @@ module TorqueBox
 
       # Get an entry from the cache 
       def get(key)
-        cache.get( key.to_s )
+        __massage_symbols( cache.get( key.to_s ) )
       end
 
       # Write an entry to the cache 
@@ -332,6 +332,24 @@ module TorqueBox
           args << expires << SECONDS
         end
         cache.send( *args ) && true
+      end
+
+      def __massage_symbols(val)
+        case val.class.to_s
+        when Hash.to_s
+          val.keys.each do |k|
+            val[__massage_symbols(k)] = __massage_symbols(val.delete(k))
+          end
+          val
+        when Array.to_s
+          val.map do |v|
+            __massage_symbols(v)
+          end
+        when Symbol.to_s
+          val.to_s.to_sym
+        else
+          val
+        end
       end
 
     end

--- a/gems/cache/spec/cache_spec.rb
+++ b/gems/cache/spec/cache_spec.rb
@@ -151,6 +151,21 @@ describe TorqueBox::Infinispan::Cache do
     @cache.get(:asymbol).should == "a value"
   end
 
+  it "should allow a Hash with Symbols as values" do
+    @cache.put(:asymbol, {:testing => 213})
+    @cache.get(:asymbol).should == {:testing => 213}
+  end
+
+  it "should allow an Array with Symbols as values" do
+    @cache.put(:asymbol, [:testing, 213])
+    @cache.get(:asymbol).should =~ [:testing, 213]
+  end
+
+  it "should allow a Symbols as a value" do
+    @cache.put(:asymbol, :testing)
+    @cache.get(:asymbol).should == :testing
+  end
+
   it "should allow symbols as keys for increment" do
     @cache.increment :countsymbol
     @cache.get(:countsymbol).should == "1"


### PR DESCRIPTION
added a method to massage values when they are retrieved from the cache.  This accounts for symbols that were created in another runtime.  Added three new tests to exercise the new code, but those tests do not actually reproduce the problem, which occurs after a redeploy.

This fixes some problems associated with ruby objects from other runtimes, but definitely not all of them. It doesn't account for classes (i.e. Hash != Hash) and it does not account for objects inside of objects other than Array and Hash.  Given that, we may not want this fix at all.
