### PR TITLE
[TORQUE-997] Dependency injection: allow configuration of directories where injectors will work

### DIFF
--- a/docs/manual/en-US/src/main/docbook/injection.xml
+++ b/docs/manual/en-US/src/main/docbook/injection.xml
@@ -52,7 +52,7 @@
         </listitem>
       </itemizedlist></para>
 
-    <para>TorqueBox supports injection for source files in the following
+    <para>By default TorqueBox supports injection for source files in the following
     locations (relative to the root directory of your application):
     <itemizedlist>
         <listitem>
@@ -93,6 +93,11 @@
 
 end</programlisting>
       </informalexample></para>
+
+    <para>
+      Paths are configurable per-app, see the <link linkend="configuring-the-scanner">configuration section</link>.
+    </para>
+
   </section>
 
   <section id="injectable-resources">
@@ -304,19 +309,73 @@ end</programlisting>
     key.</para>
   </section>
 
-  <section id="disabling-the-scanner">
-    <title>Disabling the Injection Scanner</title>
+  <section id="configuring-the-scanner">
+    <title>Configuring the Injection Scanner</title>
 
-    <para>If you're not making use of injection, you can disable the injection
-    scanner on a per-application basis. Simply add:</para>
+    <para>You can change the default values for the injection scanner
+      configuration using the <literal>injection</literal>
+      section in the deployment descriptor.
+    </para>
 
-    <para><informalexample>
-        <programlisting>injection:
-  enabled: false
-    </programlisting>
-      </informalexample></para>
+    <section id="disabling-the-scanner">
+      <title>Disabling the Injection Scanner</title>
 
-    <para>to your -knob.yml or torquebox.yml file, and injection scanning will
-    be disabled for your application.</para>
+      <para>
+        If you're not making use of injection, you can disable the injection
+        scanner on a per-application basis. Simply add:
+      </para>
+
+      <example>
+        <para>Using the DSL:<programlisting>TorqueBox.configure do
+  injection do
+    enabled false
+  end
+end</programlisting></para>
+
+        <para>Using YAML:<programlisting>injection:
+  enabled: false</programlisting></para>
+      </example>
+    </section>
+
+    <section id="configuring-paths-of-the-scanner">
+      <title>Configuring paths of the Injection Scanner</title>
+
+      <para>
+        If you want to change the default path where the Injection Scanner is
+        looking for files to inject to you can use the <literal>paths</literal>
+        attribute.
+      </para>
+
+      <para>
+        Please note that the specified paths will override the default paths.
+        The root directory is always added to the scanner.
+      </para>
+
+      <example>
+        <para>Using the DSL:<programlisting># Single directory
+TorqueBox.configure do
+  injection do
+    path "directory"
+  end
+end
+
+# Multiple directories
+TorqueBox.configure do
+  injection do
+    path ["directory1", "directory2"]
+  end
+end</programlisting></para>
+
+        <para>Using YAML:<programlisting># Single directory
+injection:
+  path: directory
+
+# Multiple directories
+injection:
+  path:
+    - directory1
+    - directory2</programlisting></para>
+      </example>
+    </section>
   </section>
 </chapter>

--- a/gems/configure/lib/torquebox/configuration/global.rb
+++ b/gems/configure/lib/torquebox/configuration/global.rb
@@ -47,7 +47,10 @@ module TorqueBox
                                                    :discrete => true),
           :environment => OptionsEntry,
           :injection   => OptionsEntry.with_settings(:validate => {
-                                                       :required => [{ :enabled => [true, false] }]
+                                                       :optional => [
+                                                                      { :enabled => [true, false] },
+                                                                      :path
+                                                                    ]
                                                      }),
           :config => OptionsEntry,
           :job         => ThingWithOptionsEntry.with_settings(:discrete => true,

--- a/integration-tests/apps/rack/injection/custom_paths/config.ru
+++ b/integration-tests/apps/rack/injection/custom_paths/config.ru
@@ -1,0 +1,3 @@
+require 'custom/app'
+
+run App.new

--- a/integration-tests/apps/rack/injection/custom_paths/custom/app.rb
+++ b/integration-tests/apps/rack/injection/custom_paths/custom/app.rb
@@ -1,0 +1,11 @@
+class App
+  include TorqueBox::Injectors
+
+  def call(env)
+    queue = fetch('/queues/inject-custom')
+
+    [200, {'Content-Type' => 'text/html'}, %Q{it worked
+<div id='queue-injected'>#{queue.nil? ? 'no' : 'yes'}</div>
+}]
+  end
+end

--- a/integration-tests/apps/rack/injection/custom_paths/torquebox.rb
+++ b/integration-tests/apps/rack/injection/custom_paths/torquebox.rb
@@ -1,0 +1,8 @@
+TorqueBox.configure do
+  queue '/queues/inject-custom'
+
+  injection do
+    enabled true
+    path "custom"
+  end
+end

--- a/integration-tests/apps/rack/injection/unprocessed/config.ru
+++ b/integration-tests/apps/rack/injection/unprocessed/config.ru
@@ -1,0 +1,3 @@
+require 'unprocessed/app'
+
+run App.new

--- a/integration-tests/apps/rack/injection/unprocessed/torquebox.rb
+++ b/integration-tests/apps/rack/injection/unprocessed/torquebox.rb
@@ -1,0 +1,8 @@
+TorqueBox.configure do
+  queue '/queues/inject-unprocessed'
+
+  injection do
+    enabled true
+    path "foo", "bar"
+  end
+end

--- a/integration-tests/apps/rack/injection/unprocessed/unprocessed/app.rb
+++ b/integration-tests/apps/rack/injection/unprocessed/unprocessed/app.rb
@@ -1,0 +1,11 @@
+class App
+  include TorqueBox::Injectors
+
+  def call(env)
+    queue = fetch('/queues/inject-unprocessed')
+
+    [200, {'Content-Type' => 'text/html'}, %Q{it worked
+<div id='queue-injected'>#{queue.nil? ? 'no' : 'yes'}</div>
+}]
+  end
+end

--- a/integration-tests/apps/rack/messaging/torquebox.yml
+++ b/integration-tests/apps/rack/messaging/torquebox.yml
@@ -18,7 +18,7 @@ topics:
 messaging:
   /queues/test: TestQueueConsumer
   /queues/parentless: ParentlessQueueConsumer
-  /topics/test: 
+  /topics/test:
     TestTopicConsumer:
       durable: true
       client_id: the-client

--- a/integration-tests/spec/injection_spec.rb
+++ b/integration-tests/spec/injection_spec.rb
@@ -62,3 +62,45 @@ describe "rails3 injection test" do
   end
 
 end
+
+describe "injection disabled in unknown directories" do
+  deploy <<-END.gsub(/^ {4}/,'')
+    ---
+    application:
+      root: #{File.dirname(__FILE__)}/../apps/rack/injection/unprocessed
+
+    web:
+      context: /injection-unprocessed
+
+    ruby:
+      version: #{RUBY_VERSION[0,3]}
+
+  END
+
+  it "should not inject the queue by default in 'stuff' diretory" do
+    visit "/injection-unprocessed"
+    page.should have_content('it worked')
+    find('#queue-injected').text.should eql("no")
+  end
+end
+
+describe "injection enabled in custom directories" do
+  deploy <<-END.gsub(/^ {4}/,'')
+    ---
+    application:
+      root: #{File.dirname(__FILE__)}/../apps/rack/injection/custom_paths
+
+    web:
+      context: /injection-custom
+
+    ruby:
+      version: #{RUBY_VERSION[0,3]}
+
+  END
+
+  it "should inject the queue 'stuff' diretory" do
+    visit "/injection-custom"
+    page.should have_content('it worked')
+    find('#queue-injected').text.should eql("yes")
+  end
+end

--- a/modules/core/src/main/java/org/torquebox/core/injection/InjectionMetaData.java
+++ b/modules/core/src/main/java/org/torquebox/core/injection/InjectionMetaData.java
@@ -22,9 +22,17 @@ package org.torquebox.core.injection;
 import org.jboss.as.server.deployment.AttachmentKey;
 import org.jboss.as.server.deployment.DeploymentUnit;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class InjectionMetaData {
 
+    // The default list with injection-enabled directories
+    private static final String[] DEFAULT_INJECTION_PATHS = {"app", "lib", "models", "helpers"};
+
     private boolean enabled = true;
+
+    private List<String> paths = Arrays.asList(DEFAULT_INJECTION_PATHS);
 
     public boolean isEnabled() {
         return enabled;
@@ -34,11 +42,27 @@ public class InjectionMetaData {
         this.enabled = enabled;
     }
 
-    public static final AttachmentKey<InjectionMetaData> ATTACHMENT_KEY = AttachmentKey.create( InjectionMetaData.class );    
-    
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(List<String> paths) {
+        this.paths = paths;
+    }
+
+    public static final AttachmentKey<InjectionMetaData> ATTACHMENT_KEY = AttachmentKey.create(InjectionMetaData.class);
+
     public static boolean injectionIsEnabled(DeploymentUnit unit) {
-        InjectionMetaData injectionMetaData = unit.getAttachment( ATTACHMENT_KEY );
+        InjectionMetaData injectionMetaData = unit.getAttachment(ATTACHMENT_KEY);
         return (injectionMetaData == null || injectionMetaData.isEnabled());
     }
-    
+
+    public static List<String> injectionPaths(DeploymentUnit unit) {
+        InjectionMetaData injectionMetaData = unit.getAttachment(ATTACHMENT_KEY);
+
+        if (injectionMetaData == null)
+            return Arrays.asList(DEFAULT_INJECTION_PATHS);
+        else
+            return injectionMetaData.getPaths();
+    }
 }

--- a/modules/core/src/main/java/org/torquebox/core/injection/processors/InjectionYamlParsingProcessor.java
+++ b/modules/core/src/main/java/org/torquebox/core/injection/processors/InjectionYamlParsingProcessor.java
@@ -19,16 +19,19 @@
 
 package org.torquebox.core.injection.processors;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.logging.Logger;
 import org.torquebox.core.injection.InjectionMetaData;
 import org.torquebox.core.processors.AbstractSplitYamlParsingProcessor;
 
 public class InjectionYamlParsingProcessor extends AbstractSplitYamlParsingProcessor {
 
     public InjectionYamlParsingProcessor() {
-        setSectionName( "injection" );
+        setSectionName("injection");
     }
 
     @SuppressWarnings("unchecked")
@@ -37,11 +40,27 @@ public class InjectionYamlParsingProcessor extends AbstractSplitYamlParsingProce
         Map<String, Object> injection = (Map<String, Object>) data;
         if (injection != null) {
             InjectionMetaData imd = new InjectionMetaData();
-            Boolean enabled = (Boolean) injection.get( "enabled" );
-            imd.setEnabled( enabled );
-            unit.putAttachment( InjectionMetaData.ATTACHMENT_KEY, imd );
+
+            if (injection.containsKey("enabled"))
+                imd.setEnabled((Boolean) injection.get("enabled"));
+
+            if (injection.containsKey("path")) {
+                log.trace("Using application provided injection paths for indexing");
+
+                Object o = injection.get("path");
+
+                if (o instanceof String)
+                    imd.setPaths(Arrays.asList(new String[] {(String) o}));
+                else
+                    imd.setPaths((List<String>) o);
+
+            }
+
+            unit.putAttachment(InjectionMetaData.ATTACHMENT_KEY, imd);
         }
 
     }
 
+
+    private static final Logger log = Logger.getLogger("org.torquebox.core");
 }

--- a/modules/core/src/main/resources/org/torquebox/schema.yml
+++ b/modules/core/src/main/resources/org/torquebox/schema.yml
@@ -16,6 +16,12 @@
   arbitrary: true
 -injection:
   -enabled: boolean
+  -path:
+    type:
+      - string
+      - list:
+        value-types: string
+
 -jobs:
   dependencies: /application/root
   type: map

--- a/modules/core/src/test/java/org/torquebox/core/injection/processors/InjectionYamlParsingProcessorTest.java
+++ b/modules/core/src/test/java/org/torquebox/core/injection/processors/InjectionYamlParsingProcessorTest.java
@@ -19,6 +19,8 @@
 
 package org.torquebox.core.injection.processors;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -65,6 +67,29 @@ public class InjectionYamlParsingProcessorTest extends AbstractDeploymentProcess
         InjectionMetaData injectionMetaData = unit.getAttachment( InjectionMetaData.ATTACHMENT_KEY );
         assertNotNull( injectionMetaData );
         assertFalse( injectionMetaData.isEnabled() );
-    }    
-    
+    }
+
+    @Test
+    public void testArrayPathsInjectionYml() throws Exception {
+        MockDeploymentUnit unit = deployResourceAsTorqueboxYml( "array-paths-injection.yml" );
+        InjectionMetaData injectionMetaData = unit.getAttachment( InjectionMetaData.ATTACHMENT_KEY );
+        assertNotNull( injectionMetaData );
+        assertEquals( injectionMetaData.getPaths().size(), 2 );
+
+        String[] paths = {"foo", "bar"};
+
+        assertArrayEquals( injectionMetaData.getPaths().toArray(), paths );
+    }
+
+    @Test
+    public void testSimplePathInjectionYml() throws Exception {
+        MockDeploymentUnit unit = deployResourceAsTorqueboxYml( "path-injection.yml" );
+        InjectionMetaData injectionMetaData = unit.getAttachment( InjectionMetaData.ATTACHMENT_KEY );
+        assertNotNull( injectionMetaData );
+        assertEquals( injectionMetaData.getPaths().size(), 1 );
+
+        String[] paths = {"foo"};
+
+        assertArrayEquals( injectionMetaData.getPaths().toArray(), paths );
+    }
 }

--- a/modules/core/src/test/java/org/torquebox/core/injection/processors/array-paths-injection.yml
+++ b/modules/core/src/test/java/org/torquebox/core/injection/processors/array-paths-injection.yml
@@ -1,0 +1,5 @@
+
+injection:
+  path:
+    - "foo"
+    - "bar"

--- a/modules/core/src/test/java/org/torquebox/core/injection/processors/path-injection.yml
+++ b/modules/core/src/test/java/org/torquebox/core/injection/processors/path-injection.yml
@@ -1,0 +1,3 @@
+
+injection:
+  path: "foo"

--- a/modules/jobs/src/main/java/org/torquebox/jobs/component/processors/JobComponentResolverInstaller.java
+++ b/modules/jobs/src/main/java/org/torquebox/jobs/component/processors/JobComponentResolverInstaller.java
@@ -80,7 +80,7 @@ public class JobComponentResolverInstaller extends BaseRubyComponentInstaller {
 
     protected List<String> getInjectionPathPrefixes(DeploymentPhaseContext phaseContext, String requirePath) {
 
-        final List<String> prefixes = defaultInjectionPathPrefixes();
+        final List<String> prefixes = defaultInjectionPathPrefixes(phaseContext.getDeploymentUnit());
 
         if (requirePath != null) {
             final DeploymentUnit unit = phaseContext.getDeploymentUnit();

--- a/modules/messaging/src/main/java/org/torquebox/messaging/component/processors/MessageProcessorComponentResolverInstaller.java
+++ b/modules/messaging/src/main/java/org/torquebox/messaging/component/processors/MessageProcessorComponentResolverInstaller.java
@@ -90,7 +90,7 @@ public class MessageProcessorComponentResolverInstaller extends BaseRubyComponen
 
     protected List<String> getInjectionPathPrefixes(DeploymentPhaseContext phaseContext, String requirePath) {
 
-        final List<String> prefixes = defaultInjectionPathPrefixes();
+        final List<String> prefixes = defaultInjectionPathPrefixes(phaseContext.getDeploymentUnit());
 
         if (requirePath != null) {
 

--- a/modules/services/src/main/java/org/torquebox/services/component/processors/ServiceComponentResolverInstaller.java
+++ b/modules/services/src/main/java/org/torquebox/services/component/processors/ServiceComponentResolverInstaller.java
@@ -86,7 +86,7 @@ public class ServiceComponentResolverInstaller extends BaseRubyComponentInstalle
 
     protected List<String> getInjectionPathPrefixes(DeploymentPhaseContext phaseContext, String requirePath) {
 
-        final List<String> prefixes = defaultInjectionPathPrefixes();
+        final List<String> prefixes = defaultInjectionPathPrefixes(phaseContext.getDeploymentUnit());
 
         if (requirePath != null) {
 

--- a/modules/stomp/src/main/java/org/torquebox/stomp/component/processors/StompletComponentResolverInstaller.java
+++ b/modules/stomp/src/main/java/org/torquebox/stomp/component/processors/StompletComponentResolverInstaller.java
@@ -74,7 +74,7 @@ public class StompletComponentResolverInstaller extends BaseRubyComponentInstall
 
     protected List<String> getInjectionPathPrefixes(DeploymentPhaseContext phaseContext, String requirePath) {
 
-        final List<String> prefixes = defaultInjectionPathPrefixes();
+        final List<String> prefixes = defaultInjectionPathPrefixes(phaseContext.getDeploymentUnit());
 
         if (requirePath != null) {
             final DeploymentUnit unit = phaseContext.getDeploymentUnit();

--- a/modules/web/src/main/java/org/torquebox/web/component/processors/RackApplicationComponentResolverInstaller.java
+++ b/modules/web/src/main/java/org/torquebox/web/component/processors/RackApplicationComponentResolverInstaller.java
@@ -90,7 +90,7 @@ public class RackApplicationComponentResolverInstaller extends BaseRubyComponent
         DeploymentUnit unit = phaseContext.getDeploymentUnit();
         RackMetaData rackAppMetaData = unit.getAttachment( RackMetaData.ATTACHMENT_KEY );
         
-        List<String> prefixes = defaultInjectionPathPrefixes();
+        List<String> prefixes = defaultInjectionPathPrefixes(phaseContext.getDeploymentUnit());
         prefixes.add(  rackAppMetaData.getRackUpScriptLocation() );
         
         return prefixes;


### PR DESCRIPTION
Allows to customize (override) the default paths where injection scanner will look for files to inject to. Configuration is done per-application  in application descriptor. For example:

``` ruby
TorqueBox.configure do
  injection do
    path "directory"
  end
end

TorqueBox.configure do
  injection do
    path ["directory1", "directory2"]
  end
end
```

I added also trace log statements.

Includes documentation and integration tests.

Fixes https://issues.jboss.org/browse/TORQUE-997
