### PR TITLE
[TORQUE-1014] Inconsistency in Rails session store and cache store names

### DIFF
--- a/docs/manual/en-US/src/main/docbook/cache.xml
+++ b/docs/manual/en-US/src/main/docbook/cache.xml
@@ -326,7 +326,7 @@ cache.transaction do
       the Rails cache to explicitly store and retreive values across a cluster
       you should change the default clustering mode to <code>:replicated</code>
       or <code>:distributed</code> mode.
-      <programlisting>config.cache_store = :torque_box_store, {:mode => :distributed}</programlisting>
+      <programlisting>config.cache_store = :torquebox_store, {:mode => :distributed}</programlisting>
     </para>
 
     <para> 

--- a/docs/manual/en-US/src/main/docbook/web.xml
+++ b/docs/manual/en-US/src/main/docbook/web.xml
@@ -653,7 +653,7 @@ gem 'jdbc-sqlite3'</programlisting></para>
       <para><programlisting language="ruby">module YourApp
   class Application &lt; Rails::Application
 <emphasis>
-    config.cache_store = :torque_box_store
+    config.cache_store = :torquebox_store
 </emphasis>
   end
 end</programlisting></para>
@@ -668,7 +668,7 @@ end</programlisting></para>
       clustered and <emphasis>local</emphasis> mode when not. But you
       can certainly override the defaults:</para>
 
-      <para><programlisting language="ruby">config.cache_store = :torque_box_store, {:mode =&gt; :distributed, :sync =&gt; true}</programlisting></para>
+      <para><programlisting language="ruby">config.cache_store = :torquebox_store, {:mode =&gt; :distributed, :sync =&gt; true}</programlisting></para>
 
       <para>You can even create multiple cache stores in your app, each
       potentially in a different clustering mode. You should use the

--- a/gems/cache/lib/active_support/cache/torque_box_store.rb
+++ b/gems/cache/lib/active_support/cache/torque_box_store.rb
@@ -128,3 +128,5 @@ module ActiveSupport
   end
 end
 
+# This assignment allows :torquebox_store to work as a symbol
+ActiveSupport::Cache::TorqueboxStore = ActiveSupport::Cache::TorqueBoxStore

--- a/gems/rake-support/share/rails/template.rb
+++ b/gems/rake-support/share/rails/template.rb
@@ -69,7 +69,7 @@ environment do
   <<-ENVIRONMENT
   # Use TorqueBox::Infinispan::Cache for the Rails cache store
   if defined? TorqueBox::Infinispan::Cache
-    config.cache_store = :torque_box_store
+    config.cache_store = :torquebox_store
   end
   ENVIRONMENT
 end

--- a/integration-tests/apps/rails3.1/basic/config/application.rb
+++ b/integration-tests/apps/rails3.1/basic/config/application.rb
@@ -41,6 +41,6 @@ module Basic
     config.assets.enabled = true
 
     require 'torquebox-cache'
-    config.cache_store = :torque_box_store
+    config.cache_store = :torquebox_store
   end
 end

--- a/integration-tests/apps/rails3.1/basic/config/environment.rb
+++ b/integration-tests/apps/rails3.1/basic/config/environment.rb
@@ -5,4 +5,4 @@ require File.expand_path('../application', __FILE__)
 Basic::Application.initialize!
 
 require 'torquebox-cache' # triggers TORQUE-635 error
-Basic::Application.config.cache_store = :torque_box_store
+Basic::Application.config.cache_store = :torquebox_store

--- a/integration-tests/apps/rails3.2/shared_cache/config/application.rb
+++ b/integration-tests/apps/rails3.2/shared_cache/config/application.rb
@@ -13,7 +13,7 @@ module CachingTest
   class Application < Rails::Application
     # Use TorqueBox::Infinispan::Cache for the Rails cache store
     if defined? TorqueBox::Infinispan::Cache
-      config.cache_store = :torque_box_store
+      config.cache_store = :torquebox_store
     end
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/integration-tests/apps/rails3/basic-with-cache/config/application.rb
+++ b/integration-tests/apps/rails3/basic-with-cache/config/application.rb
@@ -39,6 +39,6 @@ module Basic
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 
-    config.cache_store = :torque_box_store
+    config.cache_store = :torquebox_store
   end
 end

--- a/integration-tests/apps/rails3/basic-with-explicit-cache/config/application.rb
+++ b/integration-tests/apps/rails3/basic-with-explicit-cache/config/application.rb
@@ -39,7 +39,7 @@ module Basic
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 
-    #config.cache_store = :torque_box_store
+    #config.cache_store = :torquebox_store
     config.cache_store = ActiveSupport::Cache::TorqueBoxStore.new
   end
 end

--- a/integration-tests/apps/rails3/no_torquebox/config/application.rb
+++ b/integration-tests/apps/rails3/no_torquebox/config/application.rb
@@ -10,7 +10,7 @@ module Basic
   class Application < Rails::Application
     # Use TorqueBox::Infinispan::Cache for the Rails cache store
     if defined? TorqueBox::Infinispan::Cache
-      config.cache_store = :torque_box_store
+      config.cache_store = :torquebox_store
     end
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/integration-tests/apps/rails3/twitter/config/application.rb
+++ b/integration-tests/apps/rails3/twitter/config/application.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
-#require 'active_support/cache/torque_box_store'
+#require 'active_support/cache/torquebox_store'
 
 # If you have a Gemfile, require the gems listed there, including any gems
 # you've limited to :test, :development, or :production.
@@ -41,6 +41,6 @@ module Twitter
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 
-    config.cache_store = :torque_box_store
+    config.cache_store = :torquebox_store
   end
 end


### PR DESCRIPTION
The cache store can be accessed now with `:torquebox_cache symbol`:

``` ruby
module App
  class Application < Rails::Application
    config.cache_store = :torquebox_store
  end
end
```

I made this default in the docs and template. The `:torque_box_cache` symbol is also available.

Fixes https://issues.jboss.org/browse/TORQUE-1014
