### PR TITLE
[TORQUE-1006] Unable to use symbols to fetch session data

### DIFF
--- a/gems/web/spec/servlet_store_spec.rb
+++ b/gems/web/spec/servlet_store_spec.rb
@@ -1,0 +1,30 @@
+require 'torquebox/session/servlet_store'
+
+
+describe TorqueBox::Session::SessionData do
+
+	subject { TorqueBox::Session::SessionData.new }
+
+	it "stores symbols as strings" do
+		subject[:a] = "hello"
+		subject["a"].should == "hello"
+	end
+
+	it "stores string as strings" do
+		subject["a"] = "hello"
+		subject["a"].should == "hello"
+	end
+
+	it "retrives strings using symbols" do
+		subject["a"] = "hello"
+		subject[:a].should == "hello"
+	end
+
+	it "works with symbols even though they are stored as strings" do
+		subject[:a] = "hello"
+		subject[:a].should == "hello"
+	end
+
+end
+
+

--- a/integration-tests/apps/rails2/basic/app/views/sessioning/display_session.html.erb
+++ b/integration-tests/apps/rails2/basic/app/views/sessioning/display_session.html.erb
@@ -17,6 +17,9 @@
     <div id="a_string_java">
       <%= @java_session.getAttribute('a_string') %>
     </div>
+		<div id="a_string_ruby_fetched_with_string_key">
+      <%= session["a_string"] %>
+    </div>
   </div>
   <div id="a_boolean">
     <div id="a_boolean_ruby">
@@ -32,6 +35,9 @@
     </div>
     <div id="a_string_key_java">
       <%= @java_session.getAttribute('a_string_key') %>
+    </div>
+    <div id="a_string_key_ruby_fetched_as_a_symbol">
+      <%= session[:a_string_key] %>
     </div>
   </div>
 </div>

--- a/integration-tests/apps/rails3/basic/app/views/sessioning/display_session.html.erb
+++ b/integration-tests/apps/rails3/basic/app/views/sessioning/display_session.html.erb
@@ -17,6 +17,9 @@
     <div id="a_string_java">
       <%= @java_session.getAttribute('a_string') %>
     </div>
+		<div id="a_string_ruby_fetched_with_string_key">
+      <%= session["a_string"] %>
+    </div>
   </div>
   <div id="a_boolean">
     <div id="a_boolean_ruby">
@@ -32,6 +35,9 @@
     </div>
     <div id="a_string_key_java">
       <%= @java_session.getAttribute('a_string_key') %>
+    </div>
+    <div id="a_string_key_ruby_fetched_as_a_symbol">
+      <%= session[:a_string_key] %>
     </div>
   </div>
 </div>

--- a/integration-tests/spec/session_handling_spec.rb
+++ b/integration-tests/spec/session_handling_spec.rb
@@ -73,10 +73,12 @@ shared_examples_for "session handling" do
     find('#a_fixnum_ruby').text.should == '42'
     find('#a_fixnum_java').text.should == '42'
     find('#a_string_ruby').text.should == 'swordfish'
+    find('#a_string_ruby_fetched_with_string_key').text.should == 'swordfish'
     find('#a_string_java').text.should == 'swordfish'
     find('#a_boolean_ruby').text.should == 'true'
     find('#a_boolean_java').text.should == 'true'
     find('#a_string_key_ruby').text.should == 'tacos'
+    find('#a_string_key_ruby_fetched_as_a_symbol').text.should == 'tacos'
     find('#a_string_key_java').text.should == 'tacos'
   end
 


### PR DESCRIPTION
fixed TORQUE-1006 by making SessionData store keys as strings like rack's SessionHash
