### PR TITLE
[TORQUE-1033] Create messaging objects with a default :encoding

### DIFF
--- a/gems/messaging/lib/torquebox/messaging/destination.rb
+++ b/gems/messaging/lib/torquebox/messaging/destination.rb
@@ -107,6 +107,13 @@ module TorqueBox
 
       def with_session(opts = {})
         transactional = opts.fetch(:tx, true)
+
+        # https://issues.jboss.org/browse/TORQUE-1033
+        # If there is no encoding for the message, set the default one
+        # for the destination. If the encoding for destination isn't set
+        # it won't hurt
+        opts[:encoding] = @connect_options[:encoding] if opts[:encoding].nil?
+
         connection_factory.with_new_connection(connect_options, transactional) do |connection|
           connection.with_session do |session|
             yield session

--- a/gems/messaging/lib/torquebox/messaging/queue.rb
+++ b/gems/messaging/lib/torquebox/messaging/queue.rb
@@ -29,7 +29,7 @@ module TorqueBox
         TorqueBox::ServiceRegistry.lookup("jboss.messaging.default.jms.manager") do |server|
           server.createQueue( false, name, selector, durable, jndi )
         end
-        new( name )
+        new( name, options )
       end
 
       def stop

--- a/gems/messaging/lib/torquebox/messaging/topic.rb
+++ b/gems/messaging/lib/torquebox/messaging/topic.rb
@@ -29,7 +29,7 @@ module TorqueBox
         TorqueBox::ServiceRegistry.lookup("jboss.messaging.default.jms.manager") do |server|
           server.createTopic( false, name, jndi )
         end
-        new( name )
+        new( name, options )
       end
 
       def stop


### PR DESCRIPTION
This allows to specify default encoding when creating a queue or topic:

``` ruby
TorqueBox::Messaging::Queue.start("/queues/one", :encoding => :edn)
TorqueBox::Messaging::Topic.new("/topics/one", :encoding => :edn)
```

Added integration tests for both queues and topic.

Fixes: https://issues.jboss.org/browse/TORQUE-1033
