### PR TITLE
[TORQUE-1025] expose expireMessage, sendToDeadLetterQueue, and moveMessage methods

### DIFF
--- a/docs/manual/en-US/src/main/docbook/messaging.xml
+++ b/docs/manual/en-US/src/main/docbook/messaging.xml
@@ -950,7 +950,7 @@ queue.stop</programlisting>
                               <row>
                                   <entry>count_messages</entry>
 
-                                  <entry><parameter>filter</parameter></entry>
+                                  <entry><parameter>filter</parameter>, <parameter>destination</parameter></entry>
 
                                   <entry>
                                       Counts messages in the queue. The optional <parameter>filter</parameter>
@@ -959,6 +959,116 @@ queue.stop</programlisting>
                                       messages will be counted.
                                   </entry>
                               </row>
+
+                              <row>
+                                  <entry>move_messages</entry>
+
+                                  <entry><parameter>queue_name</parameter>, <parameter>filter</parameter>, <parameter>reject_duplicates</parameter></entry>
+
+                                  <entry>
+                                      Moves messages from the queue to another queue. The optional <parameter>filter</parameter>
+                                      parameter allows to count only selected messages by filtering them
+                                      by the properties with a SQL92-like syntax. If no filter is set, all
+                                      messages will be moved. If <parameter>reject_duplicates</parameter> parameter
+                                      is set to true it'll reject all duplicates while moving to the other queue.
+                                  </entry>
+                              </row>
+
+                              <row>
+                                  <entry>move_message</entry>
+
+                                  <entry><parameter>queue_name</parameter>, <parameter>id</parameter>, <parameter>reject_duplicates</parameter></entry>
+
+                                  <entry>
+                                      Moves the selected message (you can get the <parameter>id</parameter> like this:
+                                      <literal>message.jms_message.jms_message_id</literal>) from the queue
+                                      to another queue. If <parameter>reject_duplicates</parameter> parameter
+                                      is set to true it'll reject all duplicates while moving to the other queue.
+                                  </entry>
+                              </row>
+
+                            <row>
+                              <entry>expire_messages</entry>
+
+                              <entry><parameter>filter</parameter></entry>
+
+                              <entry>
+                                Expires messages from the queue and moves them to the expire address (by default
+                                <varname>jms.queue.ExpiryQueue</varname> queue). You can set custom expiry address by
+                                using the <methodname>expiry_address=</methodname> method. The optional <parameter>filter</parameter>
+                                parameter allows to expire only selected messages by filtering them
+                                by the properties with a SQL92-like syntax. If no filter is set, all
+                                messages will be moved.
+                              </entry>
+                            </row>
+
+                            <row>
+                              <entry>expire_message</entry>
+
+                              <entry><parameter>id</parameter></entry>
+
+                              <entry>
+                                Expires the selected message (you can get the <parameter>id</parameter> like this:
+                                <literal>message.jms_message.jms_message_id</literal>) and moves it to the
+                                expire address (by default <varname>jms.queue.ExpiryQueue</varname> queue).
+                                You can set custom expiry address by using the <methodname>expiry_address=</methodname> method.
+                              </entry>
+                            </row>
+
+                            <row>
+                              <entry>send_messages_to_dead_letter_address</entry>
+
+                              <entry><parameter>filter</parameter></entry>
+
+                              <entry>
+                                Sends messages from the queue to the dead letter address (by default
+                                <varname>jms.queue.DLQ</varname> queue). You can set custom dead letter address by
+                                using the <methodname>dead_letter_address=</methodname> method. The optional <parameter>filter</parameter>
+                                parameter allows to send only selected messages by filtering them
+                                by the properties with a SQL92-like syntax. If no filter is set, all
+                                messages will be moved.
+                              </entry>
+                            </row>
+
+                            <row>
+                              <entry>send_message_to_dead_letter_address</entry>
+
+                              <entry><parameter>id</parameter></entry>
+
+                              <entry>
+                                Expires the selected message (you can get the <parameter>id</parameter> like this:
+                                <literal>message.jms_message.jms_message_id</literal>) and moves it to the
+                                dead letter address (by default <varname>jms.queue.DLQ</varname> queue).
+                                You can set custom dead letter address by using the <methodname>dead_letter_address=</methodname> method.
+                              </entry>
+                            </row>
+
+                            <row>
+                              <entry>expiry_address</entry>
+
+                              <entry></entry>
+
+                              <entry>
+                                Using this method you can get or set the expiry address for
+                                the current queue. By default it's set to <varname>jms.queue.ExpiryQueue</varname> queue.
+                                Make sure you prefix your destination name with <varname>jms.queue.</varname> or
+                                <varname>jms.topic.</varname> depending on the type.
+                              </entry>
+                            </row>
+
+                            <row>
+                              <entry>dead_letter_address</entry>
+
+                              <entry></entry>
+
+                              <entry>
+                                Using this method you can get or set the dead letter address for
+                                the current queue. By default it's set to <varname>jms.queue.DLQ</varname> queue.
+                                Make sure you prefix your destination name with <varname>jms.queue.</varname> or
+                                <varname>jms.topic.</varname> depending on the type.
+                              </entry>
+                            </row>
+
                           </tbody>
                       </tgroup>
                   </table>

--- a/gems/messaging/lib/torquebox/messaging/queue.rb
+++ b/gems/messaging/lib/torquebox/messaging/queue.rb
@@ -105,6 +105,16 @@ module TorqueBox
         end
       end
 
+      # Removes message from the queue by its id.
+      #
+      # Returns +true+ if the message was removed,
+      # +false+ otherwise.
+      def remove_message(id)
+        with_queue_control do |control|
+          control.remove_message(id)
+        end
+      end
+
       # Counts messages in the queue.
       #
       # Accepts optional :filter parameter to count only
@@ -127,7 +137,153 @@ module TorqueBox
         end
       end
 
-      # Retrieves the JMSQueueControl implenetation for current
+      # Expires messages from the queue.
+      #
+      # Accepts optional :filter parameter to expire only
+      # selected messages in the queue. By default
+      # all messages will be expired.
+      #
+      # Returns number of expired messaged.
+      def expire_messages(filter = nil)
+        with_queue_control do |control|
+          control.expire_messages(filter)
+        end
+      end
+
+      # Expires message from the queue by its id.
+      #
+      # Returns +true+ if the message was expired,
+      # +false+ otherwise.
+      def expire_message(id)
+        with_queue_control do |control|
+          control.expire_message(id)
+        end
+      end
+
+      # Sends message to dead letter address.
+      #
+      # Returns +true+ if the message was sent,
+      # +false+ otherwise.
+      def send_message_to_dead_letter_address(id)
+        with_queue_control do |control|
+          control.send_message_to_dead_letter_address(id)
+        end
+      end
+
+      # Sends messages to dead letter address.
+      #
+      # Accepts optional :filter parameter to send only
+      # selected messages from the queue. By default
+      # all messages will be send.
+      #
+      # Returns number of sent messaged.
+      def send_messages_to_dead_letter_address(filter = nil)
+        with_queue_control do |control|
+          control.send_messages_to_dead_letter_address(filter)
+        end
+      end
+
+      # Returns the consumer count connected to the queue.
+      def consumer_count
+        with_queue_control do |control|
+          control.consumer_count
+        end
+      end
+
+      # Returns the scheduled messages count for this queue.
+      def scheduled_messages_count
+        with_queue_control do |control|
+          control.scheduled_count
+        end
+      end
+
+      # Moves messages from the queue to another queue specified in the
+      # +queue_name+ parameter. Optional +reject_duplicates+ parameter
+      # specifies if the duplicates should be rejected.
+      #
+      # The +filter+ parameter makes it possible to limit messages to
+      # move. If provided +nil+ or empty string, *all messages* will be moved.
+      #
+      # Returns number of moved messages.
+      def move_messages(queue_name, filter = nil, reject_duplicates = false)
+        with_queue_control do |control|
+          control.move_messages(filter, queue_name, reject_duplicates)
+        end
+      end
+
+      # Moves message for specific +id+ from the queue to another queue
+      # specified in the +queue_name+ parameter. Optional +reject_duplicates+
+      # parameter specifies if the duplicates should be rejected.
+      #
+      # Returns +true+ if the message was moved,
+      # +false+ otherwise.
+      def move_message(queue_name, id, reject_duplicates = false)
+        with_queue_control do |control|
+          control.move_message(id, queue_name, reject_duplicates)
+        end
+      end
+
+      # Returns current expiry address.
+      #
+      # The destination contains +jms.queue+ or +jms.topic+ prefixes,
+      def expiry_address
+        with_queue_control do |control|
+          control.expiry_address
+        end
+      end
+
+      # Sets the expiry address.
+      #
+      # Please note that you need to provide the
+      # *full address* containing the destination name and
+      # +jms.queue+ or +jms.topic+ prefixes, for example:
+      #
+      # If you want to set the destination to /queues/customexpire, use
+      # +queue.expiry_address = "jms.queue./queues./customexpire"+
+      #
+      # If you want to set the destination to /topics/customexpire, use
+      # +queue.expiry_address = "jms.topic./topics./customexpire"+
+      #
+      # Returns current expiry address.
+      def expiry_address=(address)
+        with_queue_control do |control|
+          control.set_expiry_address(address)
+        end
+
+        expiry_address
+      end
+
+      # Returns current dead letter address.
+      #
+      # The destination contains +jms.queue+ or +jms.topic+ prefixes,
+      def dead_letter_address
+        with_queue_control do |control|
+          control.dead_letter_address
+        end
+      end
+
+      # Sets the dead letter address.
+      #
+      # Please note that you need to provide the
+      # *full address* containing the destination name and
+      # +jms.queue+ or +jms.topic+ prefixes, for example:
+      #
+      # If you want to set the destination to /queues/customdead, use
+      # +queue.dead_letter_address = "jms.queue./queues./customdead"+
+      #
+      # If you want to set the destination to /topics/customdead, use
+      # +queue.dead_letter_address = "jms.topic./topics./customdead"+
+      #
+      # Returns current dead letter address.
+      def dead_letter_address=(address)
+        with_queue_control do |control|
+          control.set_dead_letter_address(address)
+        end
+
+        dead_letter_address
+      end
+
+      # Retrieves the JMSQueueControl implementation for current
       # queue.
       def with_queue_control
         TorqueBox::ServiceRegistry.lookup("jboss.messaging.default") do |server|


### PR DESCRIPTION
Exposed new queue management methods like: expire_message, expire_messages, move_message, move_messages. This commit allows also to set dead letter and expiry destination. Please read documentation in the code for usage.

Added also integration tests and documentation.

Fixes https://issues.jboss.org/browse/TORQUE-1025
