### PR TITLE
rake-support was preventing 'torquebox rails newapp' from working with Rails 4.0.0.beta

### DIFF
--- a/gems/rake-support/lib/torquebox/rails.rb
+++ b/gems/rake-support/lib/torquebox/rails.rb
@@ -34,7 +34,7 @@ module TorqueBox
       end
       ARGV << [ "-m", TorqueBox::Rails.template ]
       ARGV.flatten!
-      if using_rails3?
+      if using_rails3_or_greater?
         ::Rails::Generators::AppGenerator.start
       else
         ::Rails::Generator::Base.use_application_sources!
@@ -45,7 +45,7 @@ module TorqueBox
     def self.apply_template( root )
       print_rails_not_installed_and_exit unless rails_installed?
       require_generators
-      if using_rails3?
+      if using_rails3_or_greater?
         generator = ::Rails::Generators::AppGenerator.new( [root], {}, :destination_root => root )
         Dir.chdir(root)
         generator.apply TorqueBox::Rails.template
@@ -68,12 +68,12 @@ module TorqueBox
       exit 1
     end
 
-    def self.using_rails3?
-      ::Rails::VERSION::MAJOR == 3
+    def self.using_rails3_or_greater?
+      ::Rails::VERSION::MAJOR >= 3
     end
 
     def self.require_generators
-      if using_rails3?
+      if using_rails3_or_greater?
         require 'rails/generators'
         require 'rails/generators/rails/app/app_generator'
       else

--- a/gems/rake-support/spec/rails_spec.rb
+++ b/gems/rake-support/spec/rails_spec.rb
@@ -30,7 +30,7 @@ describe TorqueBox::Rails do
   context "Rails 3" do
     before(:each) do
       TorqueBox::Rails.stub!(:rails_installed?).and_return(true)
-      TorqueBox::Rails.stub(:using_rails3?).and_return(true)
+      TorqueBox::Rails.stub(:using_rails3_or_greater?).and_return(true)
       TorqueBox::Rails.stub(:require_generators)
       module ::Rails; module Generators; class AppGenerator; end; end; end
     end
@@ -56,7 +56,7 @@ describe TorqueBox::Rails do
   context "Rails 2" do
     before(:each) do
       TorqueBox::Rails.stub!(:rails_installed?).and_return(true)
-      TorqueBox::Rails.stub(:using_rails3?).and_return(false)
+      TorqueBox::Rails.stub(:using_rails3_or_greater?).and_return(false)
       TorqueBox::Rails.stub(:require_generators)
       module ::Rails; module Generator; class Base; end; end; end
       module ::Rails; module Generator; module Scripts; class Generate; end; end; end; end


### PR DESCRIPTION
This will allow you to create a Rails 4 app using 'torquebox rails someapp'. It previous wasn't working due to the code only handling Rails 3 otherwise falling back to Rails 2 style of app generators. Rails 4 uses the same railties generator as Rails 3.
