### PR TITLE
Move InjectionError so it's in scope when used

### DIFF
--- a/gems/core/lib/torquebox/injectors.rb
+++ b/gems/core/lib/torquebox/injectors.rb
@@ -21,6 +21,9 @@ require 'torquebox/service_registry'
 
 module TorqueBox
 
+  class InjectionError < StandardError
+  end
+
   def self.fetch(something)
     unless TorqueBox::Registry.has_key?(something.to_s)
       handler_registry = TorqueBox::ServiceRegistry['torquebox.core.injection.injectable-handler-registry']
@@ -46,9 +49,6 @@ module TorqueBox
   end
 
   module Injectors
-
-    class InjectionError < StandardError
-    end
 
     def fetch(something)
       TorqueBox.fetch(something)


### PR DESCRIPTION
I noticed that the rearrangement of Injection has caused the InjectionError to be out of scope when used in Torquebox.fetch. This simply moves the definition of InjectionError so it's in scope again.
