### PR TITLE
[TORQUE-257] Provide support for 'at' jobs

### DIFF
--- a/docs/manual/en-US/src/main/docbook/scheduled-jobs.xml
+++ b/docs/manual/en-US/src/main/docbook/scheduled-jobs.xml
@@ -434,7 +434,7 @@ end</programlisting></para>
 
                 <entry>10000</entry>
 
-                <entry>Time to wait for the job scheduling taks to complete.</entry>
+                <entry>Time to wait for the job scheduling task to complete.</entry>
               </row>
             </tbody>
           </tgroup>
@@ -491,6 +491,155 @@ end</programlisting></para>
         </para>
       </section>
     </section>
+
+  </section>
+
+  <section id="at-jobs">
+    <title>'At' Jobs</title>
+
+    <para>
+      'At' jobs are jobs that use different scheduling mechanism compared
+      to regular scheduled jobs where you define the execution time with cron
+      expressions. In case of 'at' jobs you have more control over the execution
+      of the job.
+    </para>
+
+    <para><example>
+      <title>Examples of scheduling 'at' jobs</title>
+
+      <para><programlisting># The job will be executed every 200 ms, from now, for the next 10 seconds
+TorqueBox::ScheduledJob.at('SimpleJob', :every => 200, :until => Time.now + 10)
+
+# The job will be executed for the first time in 10 seconds (current time + 10 seconds), then every
+# 500 ms, for the next 10 seconds (current time + 20 seconds)
+TorqueBox::ScheduledJob.at('SimpleJob', :at => Time.now + 10, :every => 500, :until => Time.now + 20)
+
+# The job will be executed for the first time in 5s and repeated 3 times
+# The time between executions is set to 1.5s
+TorqueBox::ScheduledJob.at('SimpleJob', :in => 5000, :repeat => 3, :every => 1500)
+</programlisting></para>
+      </example></para>
+
+      <para>
+        The first parameter of the <methodname>at</methodname> method is the class
+        name of the job implmentation to execute. The second parameter
+        allows to specify when the job should be executed.
+        Below you can find valid options.
+      </para>
+
+      <table>
+        <title>'At' job scheduling options</title>
+
+        <tgroup cols="3">
+          <colspec align="left" />
+
+          <thead>
+            <row>
+              <entry>Option</entry>
+
+              <entry>Default</entry>
+
+              <entry>Description</entry>
+            </row>
+          </thead>
+
+          <tbody>
+            <row>
+              <entry><parameter>:at</parameter></entry>
+
+              <entry>Time.now</entry>
+
+              <entry>
+                Specifies when the at job should start firing. Must be a
+                <classname>Time</classname> class. Can't be specified with
+                <parameter>:in</parameter>.
+              </entry>
+            </row>
+
+            <row>
+              <entry><parameter>:in</parameter></entry>
+
+              <entry></entry>
+
+              <entry>Specifies when the at job should start firing, in ms from now. Can't be specified with <parameter>:at</parameter>.</entry>
+            </row>
+
+            <row>
+              <entry><parameter>:every</parameter></entry>
+
+              <entry></entry>
+
+              <entry>Specifies the delay interval between at job firings, in ms. If specified without a <parameter>:repeat</parameter> or <parameter>:until</parameter>, the job will fire indefinitely.</entry>
+            </row>
+
+            <row>
+              <entry><parameter>:repeat</parameter></entry>
+
+              <entry></entry>
+
+              <entry>Specifies the number of times an at job should repeat beyond its initial firing. Requires <parameter>:every</parameter> to be provided.</entry>
+            </row>
+
+            <row>
+              <entry><parameter>:until</parameter></entry>
+
+              <entry></entry>
+
+              <entry>Specifies when the at job should stop firing. Must be a <classname>Time</classname> class.</entry>
+            </row>
+
+            <row>
+              <entry><parameter>:name</parameter></entry>
+
+              <entry>job class name</entry>
+
+              <entry>The job name unique across the application.</entry>
+            </row>
+
+            <row>
+              <entry><parameter>:description</parameter></entry>
+
+              <entry></entry>
+
+              <entry>Job description.</entry>
+            </row>
+
+            <row>
+              <entry><parameter>:timeout</parameter></entry>
+
+              <entry>"0s"</entry>
+
+              <entry>The time after the job execution should be interrupted. By default it'll
+              never interrupt the job execution.</entry>
+            </row>
+
+            <row>
+              <entry><parameter>:config</parameter></entry>
+
+              <entry></entry>
+
+              <entry>Data that should be injected to the job constructor.</entry>
+            </row>
+
+            <row>
+              <entry><parameter>:singleton</parameter></entry>
+
+              <entry>true</entry>
+
+              <entry>Flag to determine if the job should be executed on every node
+              in the cluster or only on one node (default).</entry>
+            </row>
+
+            <row>
+              <entry><parameter>:wait</parameter></entry>
+
+              <entry>10000</entry>
+
+              <entry>Time to wait for the job scheduling task to complete.</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
 
   </section>
 

--- a/gems/core/spec/scheduled_job_spec.rb
+++ b/gems/core/spec/scheduled_job_spec.rb
@@ -1,0 +1,57 @@
+require 'torquebox/scheduled_job'
+
+describe TorqueBox::ScheduledJob do
+  context "'at' jobs" do
+    it "should raise if no options are specified" do
+      lambda {
+        TorqueBox::ScheduledJob.at('Class', nil)
+      }.should raise_error("Invalid options for scheduling the job")
+    end
+
+    it "should raise if invalid options are specified" do
+      lambda {
+        TorqueBox::ScheduledJob.at('Class', "something")
+      }.should raise_error("Invalid options for scheduling the job")
+    end
+
+    it "should raise if :at and :in options are both specified" do
+      lambda {
+        TorqueBox::ScheduledJob.at('Class', :at => Time.now, :in => 2_000)
+      }.should raise_error("You can't specify both :at and :in")
+    end
+
+    it "should raise if :repeat is used without :every" do
+      lambda {
+        TorqueBox::ScheduledJob.at('Class', :at => Time.now, :repeat => 2_000)
+      }.should raise_error("You can't specify :repeat without :every")
+    end
+
+    it "should raise if :until is used without :every" do
+      lambda {
+        TorqueBox::ScheduledJob.at('Class', :at => Time.now, :until => Time.now + 2)
+      }.should raise_error("You can't specify :until without :every")
+    end
+
+    it "should raise if the :in parameter is not an Fixnum" do
+      lambda {
+        TorqueBox::ScheduledJob.at('Class', :in => Time.now)
+      }.should raise_error("Invalid type for :in, should be a Fixnum")
+
+    end
+  end
+
+  context "scheduled job" do
+    it "should raise if the job class is not provided" do
+      lambda {
+        TorqueBox::ScheduledJob.schedule(nil, '')
+      }.should raise_error("No job class name provided")
+    end
+
+    it "should raise if the cron expression is not provided" do
+      lambda {
+        TorqueBox::ScheduledJob.schedule('Class', nil)
+      }.should raise_error("No cron expression provided")
+    end
+  end
+end
+

--- a/integration-tests/apps/alacarte/at-jobs/simple_job.rb
+++ b/integration-tests/apps/alacarte/at-jobs/simple_job.rb
@@ -1,0 +1,10 @@
+class SimpleJob
+  def initialize(opts = {})
+    @response_queue = TorqueBox.fetch("/queue/response")
+  end
+
+  def run
+    puts "Running #{self} job..."
+    @response_queue.publish("Job executed!")
+  end
+end

--- a/integration-tests/apps/alacarte/at-jobs/torquebox.yml
+++ b/integration-tests/apps/alacarte/at-jobs/torquebox.yml
@@ -1,0 +1,4 @@
+queues:
+  /queue/response:
+    durable: false
+

--- a/integration-tests/spec/at_jobs_spec.rb
+++ b/integration-tests/spec/at_jobs_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+require 'torquebox-messaging'
+
+remote_describe "at jobs" do
+  deploy <<-END.gsub(/^ {4}/,'')
+    ---
+    application:
+      root: #{File.dirname(__FILE__)}/../apps/alacarte/at-jobs
+      env: development
+    ruby:
+      version: #{RUBY_VERSION[0,3]}
+  END
+
+  it "should deploy the :every, :until at job" do
+    queue = TorqueBox::Messaging::Queue.new('/queue/response')
+
+    # Every 200 ms for over 5 seconds, from now
+    TorqueBox::ScheduledJob.at('SimpleJob', :every => 220, :until => Time.now + 5)
+
+    count = 0
+
+    while (queue.receive(:timeout => 2_000))
+      count += 1
+    end
+
+    # 5 seconds, every 220 ms
+    count.should == 23
+
+    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
+  end
+
+  it "should deploy the :at, :every, :until at job" do
+    queue = TorqueBox::Messaging::Queue.new('/queue/response')
+
+    # Start in 1 second, then every 220 ms for over 4 seconds (5 seconds from now, but start is delayed)
+    TorqueBox::ScheduledJob.at('SimpleJob', :at => Time.now + 1, :every => 220, :until => Time.now + 5)
+
+    count = 0
+
+    while (queue.receive(:timeout => 2_000))
+      count += 1
+    end
+
+    # 4 seconds, every 220 ms
+    count.should == 19
+
+    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
+  end
+
+  it "should deploy the :in, :repeat, :until at job" do
+    queue = TorqueBox::Messaging::Queue.new('/queue/response')
+
+    # Start in 1 second, then every 220 ms for over 4 seconds (5 seconds from now, but start is delayed)
+    TorqueBox::ScheduledJob.at('SimpleJob', :in => 1_000, :every => 220, :until => Time.now + 5)
+
+    count = 0
+
+    while (queue.receive(:timeout => 2_000))
+      count += 1
+    end
+
+    # 4 seconds, every 220 ms
+    count.should == 19
+
+    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
+  end
+
+  it "should deploy the :in, :repeat, :every at job" do
+    queue = TorqueBox::Messaging::Queue.new('/queue/response')
+
+    # Start in 1 second, then repeat te job 10 times, every 150 ms
+    TorqueBox::ScheduledJob.at('SimpleJob', :in => 1_000, :repeat => 10, :every => 150)
+
+    count = 0
+
+    while (queue.receive(:timeout => 2_000))
+      count += 1
+    end
+
+    # 11, because the first execution is not counted
+    count.should == 11
+
+    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
+  end
+end

--- a/modules/jobs/src/main/java/org/torquebox/jobs/AtJob.java
+++ b/modules/jobs/src/main/java/org/torquebox/jobs/AtJob.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2008-2013 Red Hat, Inc, and individual contributors.
+ * 
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.torquebox.jobs;
+
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.msc.value.Value;
+import org.projectodd.polyglot.core.util.TimeInterval;
+import org.projectodd.polyglot.jobs.BaseAtJob;
+import org.quartz.SchedulerException;
+import org.torquebox.core.component.ComponentResolver;
+import org.torquebox.core.runtime.RubyRuntimePool;
+
+import java.text.ParseException;
+
+public class AtJob extends BaseAtJob implements AtJobMBean {
+    public AtJob(String group, TimeInterval timeout, String name, String description, boolean singleton) {
+        super(RubyJobProxy.class, group, name, description, timeout, singleton);
+    }
+
+    @Override
+    public synchronized void start() throws ParseException, SchedulerException {
+        super.start();
+        JobScheduler jobScheduler = (JobScheduler) ((Value) getJobSchedulerInjector()).getValue();
+        jobScheduler.addComponentResolver(getKey(), this.componentResolverInjector.getValue());
+    }
+
+    public Injector<ComponentResolver> getComponentResolverInjector() {
+        return componentResolverInjector;
+    }
+
+    public Injector<RubyRuntimePool> getRubyRuntimePoolInjector() {
+        return this.rubyRuntimePoolInjector;
+    }
+
+    private InjectedValue<ComponentResolver> componentResolverInjector = new InjectedValue<ComponentResolver>();
+    private InjectedValue<RubyRuntimePool> rubyRuntimePoolInjector = new InjectedValue<RubyRuntimePool>();
+}

--- a/modules/jobs/src/main/java/org/torquebox/jobs/AtJobMBean.java
+++ b/modules/jobs/src/main/java/org/torquebox/jobs/AtJobMBean.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-2013 Red Hat, Inc, and individual contributors.
+ * 
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.torquebox.jobs;
+
+import org.projectodd.polyglot.jobs.BaseJobMBean;
+
+public interface AtJobMBean extends BaseJobMBean {
+  
+
+}


### PR DESCRIPTION
Added suport for new way of scheduling jobs:

``` ruby
# The job will be executed every 200 ms, from now, for the next 10 seconds
TorqueBox::ScheduledJob.at('SimpleJob', :every => 200, :until => Time.now + 10)

# The job will be executed for the first time in 10 seconds (current time + 10 seconds), then every 500 ms, for the next 10 seconds (current time + 20 seconds)
TorqueBox::ScheduledJob.at('SimpleJob', :at => Time.now + 10, :every => 500, :until => Time.now + 20)

# The job will be executed for the first time in 5s and repeated 3 times. The time between executions is set to 1.5s
TorqueBox::ScheduledJob.at('SimpleJob', :in => 5000, :repeat => 3, :every => 1500)
```

Added integration tests and documentation.
