### PR TITLE
Fix for [TORQUE-1069] and [TORQUE-1053]

### DIFF
--- a/modules/messaging/src/main/java/org/torquebox/messaging/Destinationizer.java
+++ b/modules/messaging/src/main/java/org/torquebox/messaging/Destinationizer.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2008-2013 Red Hat, Inc, and individual contributors.
+ * 
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.torquebox.messaging;
+
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.projectodd.polyglot.core.AtRuntimeInstaller;
+import org.projectodd.polyglot.core.HasStartStopLatches;
+import org.projectodd.polyglot.messaging.destinations.DestinationUtils;
+import org.projectodd.polyglot.messaging.destinations.Destroyable;
+import org.projectodd.polyglot.messaging.destinations.DestroyableJMSQueueService;
+import org.projectodd.polyglot.messaging.destinations.DestroyableJMSTopicService;
+import org.projectodd.polyglot.messaging.destinations.QueueMetaData;
+import org.projectodd.polyglot.messaging.destinations.TopicMetaData;
+import org.projectodd.polyglot.messaging.destinations.processors.QueueInstaller;
+import org.projectodd.polyglot.messaging.destinations.processors.TopicInstaller;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A class to manage the destinations at runtime. It allows to create and remove destinations (queues and topics).
+ *
+ * @author Marek Goldmann
+ */
+public class Destinationizer extends AtRuntimeInstaller<Destinationizer> {
+
+    public Destinationizer(DeploymentUnit unit, ServiceTarget globalServiceTarget) {
+        super(unit, globalServiceTarget);
+    }
+
+    /**
+     * With the service start the queues and topics listed in the metadata are deployed.
+     *
+     * @param context
+     * @throws StartException
+     * @see QueueMetaData
+     * @see TopicMetaData
+     */
+    @Override
+    public void start(StartContext context) throws StartException {
+        super.start(context);
+
+        List<QueueMetaData> queueMetaDatas = getUnit().getAttachmentList(QueueMetaData.ATTACHMENTS_KEY);
+
+        if (queueMetaDatas != null && queueMetaDatas.size() > 0) {
+
+            log.debugf("Installing %s queues listed in deployment descriptors...", queueMetaDatas.size());
+
+            for (QueueMetaData metaData : queueMetaDatas) {
+                if (!metaData.isRemote()) {
+
+                    log.debugf("Deploying '%s' queue...", metaData.getName());
+
+                    createQueue(
+                            metaData.getName(),
+                            metaData.isDurable(),
+                            metaData.getSelector(),
+                            metaData.isExported()
+                    );
+                }
+            }
+        }
+
+        List<TopicMetaData> topicMetaDatas = getUnit().getAttachmentList(TopicMetaData.ATTACHMENTS_KEY);
+
+        if (topicMetaDatas != null && topicMetaDatas.size() > 0) {
+
+            log.debugf("Installing %s topics listed in deployment descriptors...", topicMetaDatas.size());
+
+            for (TopicMetaData metaData : topicMetaDatas) {
+                if (!metaData.isRemote()) {
+
+                    log.debugf("Deploying '%s' topic...", metaData.getName());
+
+                    createTopic(
+                            metaData.getName(),
+                            metaData.isExported()
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates a new queue by deploying required services.
+     * <p/>
+     * This method is executed asynchronously.
+     *
+     * @param queueName The queue name
+     * @param durable   If the queue should be durable
+     * @param selector  The optional selector used for the queue
+     * @param exported  If the queue should be available in remote JNDI lookups
+     * @return CountDownLatch The latch to check if the service is fully started
+     * @see DestroyableJMSQueueService
+     * @see CountDownLatch
+     */
+    public CountDownLatch createQueue(final String queueName, final boolean durable, final String selector, boolean exported) {
+        if (DestinationUtils.destinationPointerExists(getUnit(), queueName)) {
+            log.debugf("Service for '%s' queue already exists", queueName);
+            return new CountDownLatch(0);
+        }
+
+        DestroyableJMSQueueService queue =
+                QueueInstaller.deployGlobalQueue(getUnit().getServiceRegistry(),
+                        getGlobalTarget(),
+                        queueName,
+                        durable,
+                        selector,
+                        DestinationUtils.jndiNames(queueName, exported));
+
+        createDestinationService(
+                queueName,
+                QueueInstaller.queueServiceName(queueName),
+                queue.getReferenceCount()
+        );
+
+        return queue.getStartLatch();
+    }
+
+    /**
+     * Creates a new topic by deploying required services.
+     * <p/>
+     * This method is executed asynchronously.
+     *
+     * @param topicName The name of the topic
+     * @param exported  If the topic should be accessible in remote JNDI lookups
+     * @return CountDownLatch The latch to check if the service is fully started
+     * @see DestroyableJMSTopicService
+     * @see CountDownLatch
+     */
+    public CountDownLatch createTopic(String topicName, boolean exported) {
+        if (DestinationUtils.destinationPointerExists(getUnit(), topicName)) {
+            log.debugf("Service for '%s' topic already exists", topicName);
+            return new CountDownLatch(0);
+        }
+
+        DestroyableJMSTopicService topic =
+                TopicInstaller.deployGlobalTopic(getUnit().getServiceRegistry(),
+                        getGlobalTarget(),
+                        topicName,
+                        DestinationUtils.jndiNames(topicName, exported));
+
+        createDestinationService(
+                topicName,
+                TopicInstaller.topicServiceName(topicName),
+                topic.getReferenceCount()
+        );
+
+        return topic.getStartLatch();
+    }
+
+    /**
+     * Removes the destination (queue or topic) by undeploying the services.
+     * <p/>
+     * This method is executed asynchronously.
+     *
+     * @param name Name of the destination (queue or topic)
+     * @return CountDownLatch The latch to check if the service is fully stopped
+     * @see CountDownLatch
+     */
+    @SuppressWarnings({"rawtypes", "unchecked", "unused"})
+    public CountDownLatch removeDestination(String name) {
+        ServiceName serviceName = this.destinations.get(name);
+        if (serviceName != null) {
+            ServiceRegistry registry = getUnit().getServiceRegistry();
+            ServiceController dest = registry.getService(serviceName);
+            if (dest != null) {
+                ServiceController globalDest =
+                        registry.getService(QueueInstaller.queueServiceName(name));
+                if (globalDest == null) {
+                    globalDest = registry.getService(TopicInstaller.topicServiceName(name));
+                }
+                if (globalDest == null) {
+                    //should never happen, but...
+                    throw new IllegalStateException("Failed to find global dest for " + name);
+                }
+
+                Object service = globalDest.getService();
+                //force it to destroy, even if it's durable
+                if (service instanceof Destroyable) {
+                    ((Destroyable) service).setShouldDestroy(true);
+                }
+
+                dest.setMode(Mode.REMOVE);
+
+                if (service instanceof HasStartStopLatches) {
+                    return ((HasStartStopLatches) service).getStopLatch();
+                }
+            }
+            this.destinations.remove(name);
+        }
+
+        // In case the service is already removed or the service is not created by TB, return a dummy CountDownLatch.
+        return new CountDownLatch(0);
+    }
+
+    protected void createDestinationService(String destName,
+                                            ServiceName globalName,
+                                            AtomicInteger referenceCount) {
+        this.destinations.put(destName,
+                DestinationUtils.deployDestinationPointerService(
+                        getUnit(),
+                        getTarget(),
+                        destName,
+                        globalName,
+                        referenceCount
+                ));
+    }
+
+    // Useful for testing
+    @SuppressWarnings("unused")
+    public Map<String, ServiceName> getDestinations() {
+        return this.destinations;
+    }
+
+    private Map<String, ServiceName> destinations = new HashMap<String, ServiceName>();
+
+    static final Logger log = Logger.getLogger("org.torquebox.messaging");
+}

--- a/modules/messaging/src/main/java/org/torquebox/messaging/as/MessagingServices.java
+++ b/modules/messaging/src/main/java/org/torquebox/messaging/as/MessagingServices.java
@@ -31,7 +31,8 @@ public class MessagingServices {
     public static final ServiceName MESSAGING = CoreServices.TORQUEBOX.append( "messaging" );
     public static final ServiceName RUBY_CONNECTION_FACTORY = MESSAGING.append(  "ruby-connection-factory" );
     public static final ServiceName RUBY_XA_CONNECTION_FACTORY = MESSAGING.append(  "ruby-xa-connection-factory" );
-    
+    public static final ServiceName DESTINATIONIZER = MESSAGING.append( "destinationizer" );
+
     public static final ServiceName WEBSOCKETS = MESSAGING.append( "websockets" );
     public static final ServiceName WEBSOCKETS_SERVER = WEBSOCKETS.append( "server" );
 
@@ -45,6 +46,10 @@ public class MessagingServices {
 
     public static ServiceName webSocketProcessor(DeploymentUnit unit) {
         return unit.getServiceName().append( WEBSOCKETS ).append( "processor"  );
+    }
+
+    public static ServiceName destinationizer(DeploymentUnit unit) {
+        return unit.getServiceName().append( DESTINATIONIZER );
     }
 
     public static ServiceName webSocketProcessorComponentResolver(DeploymentUnit unit) {

--- a/modules/messaging/src/main/java/org/torquebox/messaging/as/MessagingSubsystemAdd.java
+++ b/modules/messaging/src/main/java/org/torquebox/messaging/as/MessagingSubsystemAdd.java
@@ -56,6 +56,7 @@ import org.torquebox.messaging.destinations.processors.TopicsYamlParsingProcesso
 import org.torquebox.messaging.injection.RubyConnectionFactoryService;
 import org.torquebox.messaging.injection.RubyXaConnectionFactoryService;
 import org.torquebox.messaging.processors.BackgroundablePresetsProcessor;
+import org.torquebox.messaging.processors.DestinationizerInstaller;
 import org.torquebox.messaging.processors.MessageProcessorInstaller;
 import org.torquebox.messaging.processors.MessagingLoadPathProcessor;
 import org.torquebox.messaging.processors.MessagingRuntimePoolProcessor;
@@ -102,11 +103,10 @@ class MessagingSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         processorTarget.addDeploymentProcessor( MessagingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, 220, rootSafe( new TasksInstaller() ) );
         processorTarget.addDeploymentProcessor( MessagingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, 320, rootSafe( new MessagingRuntimePoolProcessor() ) );
+        processorTarget.addDeploymentProcessor( MessagingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, 420, new DestinationizerInstaller(globalTarget) );
 
         processorTarget.addDeploymentProcessor( MessagingExtension.SUBSYSTEM_NAME, Phase.INSTALL, 120, rootSafe( new MessageProcessorComponentResolverInstaller() ) );
         processorTarget.addDeploymentProcessor( MessagingExtension.SUBSYSTEM_NAME, Phase.INSTALL, 220, rootSafe( new MessageProcessorInstaller() ) );
-        processorTarget.addDeploymentProcessor( MessagingExtension.SUBSYSTEM_NAME, Phase.INSTALL, 221, new QueueInstaller(globalTarget) );
-        processorTarget.addDeploymentProcessor( MessagingExtension.SUBSYSTEM_NAME, Phase.INSTALL, 222, new TopicInstaller(globalTarget) );
     }
 
     protected void addMessagingServices(final OperationContext context, ServiceVerificationHandler verificationHandler,

--- a/modules/messaging/src/main/java/org/torquebox/messaging/processors/DestinationizerInstaller.java
+++ b/modules/messaging/src/main/java/org/torquebox/messaging/processors/DestinationizerInstaller.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2008-2013 Red Hat, Inc, and individual contributors.
+ * 
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.torquebox.messaging.processors;
+
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.ServiceController.Mode;
+import org.jboss.msc.service.ServiceTarget;
+import org.torquebox.core.app.RubyAppMetaData;
+import org.torquebox.messaging.Destinationizer;
+import org.torquebox.messaging.as.MessagingServices;
+
+/**
+ * @author Marek Goldmann
+ */
+public class DestinationizerInstaller implements DeploymentUnitProcessor {
+
+    private static final Logger log = Logger.getLogger("org.torquebox.messaging");
+
+    private ServiceTarget globalTarget;
+
+    public DestinationizerInstaller(ServiceTarget globalTarget) {
+        this.globalTarget = globalTarget;
+    }
+
+    @Override
+    public void deploy(DeploymentPhaseContext context) throws DeploymentUnitProcessingException {
+        DeploymentUnit unit = context.getDeploymentUnit();
+
+        if (!unit.hasAttachment(RubyAppMetaData.ATTACHMENT_KEY)) {
+            return;
+        }
+
+        Destinationizer service = new Destinationizer(unit, globalTarget);
+
+        log.debugf("Deploying destinationizer for deployment unit '%s'", unit.getName());
+
+        context.getServiceTarget().addService(MessagingServices.destinationizer(unit), service)
+                .setInitialMode(Mode.ACTIVE)
+                .install();
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit unit) {
+    }
+}


### PR DESCRIPTION
[TORQUE-1069] Make it possible to create queues and topic at runtime in the way they are created currently at boot time
[TORQUE-1053] Use QueueInstaller to create queues using TorqueBox::Messaging::Queue.start method

https://issues.jboss.org/browse/TORQUE-1069
https://issues.jboss.org/browse/TORQUE-1053

This commit fixes both issues. The newly introduced `Destinationizer`
service is now responsible for creating destinations (queues and topic)
across TorqueBox. It does not talk directly to the HornetQ server and it
utilizes the `QueueInstaller` (or `TopicInstaller`) classes from polyglot.

The change itself results in a small overhead when creating the queues
(two MSC services are deployed) but it's a trade-off to have the
destination creation process same across different deployment methods.

This way we end up with a consistent creation of the destinations, both
at deployment and at runtime.

Destinationizer itself executes the creation in an asynchronous way
returning CountDownLatch to optionally wait for the task completion.

Additionally the TorqueBox::Messaging::Queue and
TorqueBox::Messaging::Topic documentation was rewritten to use the
proper yardoc tags.
