### PR TITLE
Changes to the way scheduled jobs are created

### DIFF
--- a/docs/manual/en-US/src/main/docbook/scheduled-jobs.xml
+++ b/docs/manual/en-US/src/main/docbook/scheduled-jobs.xml
@@ -362,6 +362,15 @@ end</programlisting></para>
         </para>
 
         <para>
+          The <methodname>schedule</methodname> method is executed asynchronously and returns
+          a <classname>java.util.concurrent.CountDownLatch</classname> object which can be used
+          to wait for the task completion. If you want to have a synchronous method
+          use the <methodname>schedule_sync</methodname> method. It will block and return
+          <constant>true</constant> after successful task completion and
+          <constant>false</constant> otherwise.
+        </para>
+
+        <para>
           The job class name and cron expression is required. Additionally
           the <methodname>schedule</methodname> method accepts following,
           optional parameters:
@@ -462,6 +471,15 @@ end</programlisting></para>
         </para>
 
         <para>
+          The <methodname>remove</methodname> method is executed asynchronously and returns
+          a <classname>java.util.concurrent.CountDownLatch</classname> object which can be used
+          to wait for the task completion. If you want to have a synchronous method
+          use the <methodname>remove_sync</methodname> method. It will block and return
+          <constant>true</constant> after successful task completion and
+          <constant>false</constant> otherwise.
+        </para>
+
+        <para>
           <example>
             <title>Removing a job</title>
             <para><programlisting>TorqueBox::ScheduledJob.remove('simple.job')</programlisting>
@@ -508,8 +526,17 @@ TorqueBox::ScheduledJob.at('SimpleJob', :in => 5000, :repeat => 3, :every => 150
       </example></para>
 
       <para>
+        The <methodname>at</methodname> method is executed asynchronously and returns
+        a <classname>java.util.concurrent.CountDownLatch</classname> object which can be used
+        to wait for the task completion. If you want to have a synchronous method
+        use the <methodname>at_sync</methodname> method. It will block and return
+        <constant>true</constant> after successful task completion and
+        <constant>false</constant> otherwise.
+      </para>
+
+      <para>
         The first parameter of the <methodname>at</methodname> method is the class
-        name of the job implmentation to execute. The second parameter
+        name of the job implementation to execute. The second parameter
         allows to specify when the job should be executed.
         Below you can find valid options.
       </para>

--- a/integration-tests/spec/alacarte_spec.rb
+++ b/integration-tests/spec/alacarte_spec.rb
@@ -81,7 +81,7 @@ describe "jobs alacarte" do
     it "should remove a job by name" do
       job = TorqueBox::ScheduledJob.lookup('job.one')
       job.name.should == 'job.one'
-      TorqueBox::ScheduledJob.remove('job.one')
+      TorqueBox::ScheduledJob.remove_sync('job.one')
       TorqueBox::ScheduledJob.lookup('job.one').should == nil
     end
 
@@ -111,7 +111,7 @@ remote_describe "runtime jobs alacarte" do
     queue = TorqueBox::Messaging::Queue.new("/queue/runtime_response")
 
     TorqueBox::ScheduledJob.list.count.should == 0
-    TorqueBox::ScheduledJob.schedule('SimpleJob', "*/1 * * * * ?", :config => {"queue" => queue.name}).should == true
+    TorqueBox::ScheduledJob.schedule_sync('SimpleJob', "*/1 * * * * ?", :config => {"queue" => queue.name}).should == true
     TorqueBox::ScheduledJob.list.count.should == 1
 
     5.times do
@@ -124,14 +124,14 @@ remote_describe "runtime jobs alacarte" do
     job.name.should == 'SimpleJob'
     job.is_singleton.should == true
 
-    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
+    TorqueBox::ScheduledJob.remove_sync('SimpleJob').should == true
     TorqueBox::ScheduledJob.list.count.should == 0
   end
 
 
   it "should deploy the job with different name" do
     TorqueBox::ScheduledJob.list.count.should == 0
-    TorqueBox::ScheduledJob.schedule('SimpleJob', "*/10 * * * * ?", :name => "simple.job").should == true
+    TorqueBox::ScheduledJob.schedule_sync('SimpleJob', "*/10 * * * * ?", :name => "simple.job").should == true
     TorqueBox::ScheduledJob.list.count.should == 1
 
     job = TorqueBox::ScheduledJob.lookup('simple.job')
@@ -141,13 +141,13 @@ remote_describe "runtime jobs alacarte" do
     end
     job.status.should == 'STARTED'
 
-    TorqueBox::ScheduledJob.remove('simple.job').should == true
+    TorqueBox::ScheduledJob.remove_sync('simple.job').should == true
     TorqueBox::ScheduledJob.list.count.should == 0
   end
 
   it "should deploy the job with config" do
     TorqueBox::ScheduledJob.list.count.should == 0
-    TorqueBox::ScheduledJob.schedule('SimpleJob', "*/10 * * * * ?", :name => "simple.config.job", :config => {:text => "text", :hash => {:a => 2}}).should == true
+    TorqueBox::ScheduledJob.schedule_sync('SimpleJob', "*/10 * * * * ?", :name => "simple.config.job", :config => {:text => "text", :hash => {:a => 2}}).should == true
     TorqueBox::ScheduledJob.list.count.should == 1
 
     job = TorqueBox::ScheduledJob.lookup('simple.config.job')
@@ -157,53 +157,53 @@ remote_describe "runtime jobs alacarte" do
     end
     job.status.should == 'STARTED'
 
-    TorqueBox::ScheduledJob.remove('simple.config.job').should == true
+    TorqueBox::ScheduledJob.remove_sync('simple.config.job').should == true
     TorqueBox::ScheduledJob.list.count.should == 0
   end
 
   it "should replace a job" do
     TorqueBox::ScheduledJob.list.count.should == 0
-    TorqueBox::ScheduledJob.schedule('SimpleJob', "*/10 * * * * ?", :description => "something").should == true
+    TorqueBox::ScheduledJob.schedule_sync('SimpleJob', "*/10 * * * * ?", :description => "something").should == true
     TorqueBox::ScheduledJob.list.count.should == 1
 
     job = TorqueBox::ScheduledJob.lookup('SimpleJob')
     job.name.should == 'SimpleJob'
     job.description.should == 'something'
 
-    TorqueBox::ScheduledJob.schedule('SimpleJob', "*/5 * * * * ?", :description => "new job").should == true
+    TorqueBox::ScheduledJob.schedule_sync('SimpleJob', "*/5 * * * * ?", :description => "new job").should == true
     TorqueBox::ScheduledJob.list.count.should == 1
 
     job = TorqueBox::ScheduledJob.lookup('SimpleJob')
     job.name.should == 'SimpleJob'
     job.description.should == 'new job'
 
-    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
+    TorqueBox::ScheduledJob.remove_sync('SimpleJob').should == true
     TorqueBox::ScheduledJob.list.count.should == 0
   end
 
   it "should not fail when the job class name includes module" do
-    TorqueBox::ScheduledJob.schedule('SomeModule::AnotherSimpleJob', "*/5 * * * * ?").should == true
+    TorqueBox::ScheduledJob.schedule_sync('SomeModule::AnotherSimpleJob', "*/5 * * * * ?").should == true
 
     TorqueBox::ScheduledJob.list.count.should == 1
 
     job = TorqueBox::ScheduledJob.lookup('SomeModule.AnotherSimpleJob')
     job.name.should == 'SomeModule.AnotherSimpleJob'
 
-    TorqueBox::ScheduledJob.remove('SomeModule.AnotherSimpleJob').should == true
+    TorqueBox::ScheduledJob.remove_sync('SomeModule.AnotherSimpleJob').should == true
 
     TorqueBox::ScheduledJob.list.count.should == 0
   end
 
   it "should not replace a job when the class differ" do
     TorqueBox::ScheduledJob.list.count.should == 0
-    TorqueBox::ScheduledJob.schedule('SimpleJob', "*/10 * * * * ?", :description => "something").should == true
+    TorqueBox::ScheduledJob.schedule_sync('SimpleJob', "*/10 * * * * ?", :description => "something").should == true
     TorqueBox::ScheduledJob.list.count.should == 1
 
     job = TorqueBox::ScheduledJob.lookup('SimpleJob')
     job.name.should == 'SimpleJob'
     job.description.should == 'something'
 
-    TorqueBox::ScheduledJob.schedule('SomeModule::AnotherSimpleJob', "*/5 * * * * ?", :description => "another something").should == true
+    TorqueBox::ScheduledJob.schedule_sync('SomeModule::AnotherSimpleJob', "*/5 * * * * ?", :description => "another something").should == true
 
     TorqueBox::ScheduledJob.list.count.should == 2
 
@@ -211,15 +211,15 @@ remote_describe "runtime jobs alacarte" do
     job.name.should == 'SomeModule.AnotherSimpleJob'
     job.description.should == 'another something'
 
-    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
-    TorqueBox::ScheduledJob.remove('SomeModule.AnotherSimpleJob').should == true
+    TorqueBox::ScheduledJob.remove_sync('SimpleJob').should == true
+    TorqueBox::ScheduledJob.remove_sync('SomeModule.AnotherSimpleJob').should == true
 
     TorqueBox::ScheduledJob.list.count.should == 0
   end
 
   it "should deploy the job stopped" do
     TorqueBox::ScheduledJob.list.count.should == 0
-    TorqueBox::ScheduledJob.schedule('SimpleJob', "*/5 * * * * ?", :stopped => true).should == true
+    TorqueBox::ScheduledJob.schedule_sync('SimpleJob', "*/5 * * * * ?", :stopped => true).should == true
     TorqueBox::ScheduledJob.list.count.should == 1
 
     job = TorqueBox::ScheduledJob.lookup('SimpleJob')
@@ -228,7 +228,7 @@ remote_describe "runtime jobs alacarte" do
     job.start
     job.status.should == 'STARTED'
 
-    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
+    TorqueBox::ScheduledJob.remove_sync('SimpleJob').should == true
   end
 end
 

--- a/integration-tests/spec/at_jobs_spec.rb
+++ b/integration-tests/spec/at_jobs_spec.rb
@@ -27,7 +27,7 @@ remote_describe "at jobs" do
     # 5 seconds, every 440 ms
     count.should == 12
 
-    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
+    TorqueBox::ScheduledJob.remove_sync('SimpleJob').should == true
   end
 
   it "should deploy the :at, :every, :until at job" do
@@ -46,7 +46,7 @@ remote_describe "at jobs" do
     # 4 seconds, every 460 ms
     count.should == 9
 
-    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
+    TorqueBox::ScheduledJob.remove_sync('SimpleJob').should == true
   end
 
   it "should deploy the :in, :repeat, :until at job" do
@@ -65,14 +65,14 @@ remote_describe "at jobs" do
     # 4 seconds, every 220 ms
     count.should == 9
 
-    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
+    TorqueBox::ScheduledJob.remove_sync('SimpleJob').should == true
   end
 
   it "should deploy the :in, :repeat, :every at job" do
     queue = TorqueBox::Messaging::Queue.new('/queue/response')
 
     # Start in 1 second, then repeat te job 10 times, every 150 ms
-    TorqueBox::ScheduledJob.at('SimpleJob', :in => 1_000, :repeat => 10, :every => 150)
+    TorqueBox::ScheduledJob.at_sync('SimpleJob', :in => 1_000, :repeat => 10, :every => 150).should == true
 
     # First run takes the longest while job installs
     count = queue.receive(:timeout => 5_000).nil? ? 0 : 1
@@ -84,6 +84,6 @@ remote_describe "at jobs" do
     # 11, because the first execution is not counted
     count.should == 11
 
-    TorqueBox::ScheduledJob.remove('SimpleJob').should == true
+    TorqueBox::ScheduledJob.remove_sync('SimpleJob').should == true
   end
 end


### PR DESCRIPTION
In general - it's async by default now.

Now the runtime scheduling using the .schedule and .at methods are executed asynchronously by default.
This can be changed by providing the :async option and setting it to
false.

Now the JobSchedulizer returns the CountDownLatch object so we can block
(if needed) to wait for the task completion or save it for later use.
