### PR TITLE
Wrap javascript code in an array in Rack response

### DIFF
--- a/gems/stomp/lib/torquebox/stomp/rack/stomp_javascript_client_provider.rb
+++ b/gems/stomp/lib/torquebox/stomp/rack/stomp_javascript_client_provider.rb
@@ -38,7 +38,7 @@ module TorqueBox
         [ 200,
           { 'Content-Length' => "#{js.size}",
             'Content-Type'   => 'text/plain' },
-          js ]
+          [js] ]
       end
 
     end 


### PR DESCRIPTION
See: [TORQUE-1081](https://issues.jboss.org/browse/TORQUE-1081)

`File.read` returns a String. String does not respond to `#each` and is therefore not a valid response body for a rack response. The Rack spec makes this clear:

> The Body must respond to each and must only yield String values. The Body itself should not be an instance of String, as this will break in Ruby 1.9.

This just wraps the resulting String in an Array, which is standard practice for this sort of thing.
