### PR TITLE
Fix NameError that sometimes occurs when dechunking a responses

### DIFF
--- a/modules/web/src/main/java/org/torquebox/web/rack/response_handler.rb
+++ b/modules/web/src/main/java/org/torquebox/web/rack/response_handler.rb
@@ -81,7 +81,7 @@ module TorqueBox
           if $1.to_i(16) == $2.bytesize
             $2
           else
-            line
+            chunk
           end
         else
           chunk


### PR DESCRIPTION
This commit fixes the following error:

```
Error invoking Rack filter: org.jruby.exceptions.RaiseException: (NameError) undefined local variable or method `line' for TorqueBox::Rack::ResponseHandler:Class
``
```
