### PR TITLE
[TORQUE-959] expose the message_ttl for backgroundable futures

### DIFF
--- a/docs/manual/en-US/src/main/docbook/messaging.xml
+++ b/docs/manual/en-US/src/main/docbook/messaging.xml
@@ -2244,6 +2244,13 @@ Widget.background(:ttl =&gt; 1000, :persistent =&gt; false).monetize
           invocation.</para>
         </example>
 
+      <para>
+        Additionally you can define the <varname>future_ttl</varname> option
+        which sets the time (in miliseconds) to wait before moving the
+        not received future to the expiry queue. By default it's set to
+        600000 (10 minutes).
+      </para>
+
       </section>
 
       <section id="backgroundable-message-processor-options">

--- a/gems/messaging/lib/torquebox/messaging/backgroundable.rb
+++ b/gems/messaging/lib/torquebox/messaging/backgroundable.rb
@@ -193,6 +193,7 @@ module TorqueBox
             queue.publish( {:receiver => receiver,
                              :future_id => future.correlation_id,
                              :future_queue => queue_name,
+                             :future_ttl => options[:future_ttl],
                              :method => method,
                              :args => args}, options )
 

--- a/gems/messaging/lib/torquebox/messaging/backgroundable_processor.rb
+++ b/gems/messaging/lib/torquebox/messaging/backgroundable_processor.rb
@@ -30,7 +30,7 @@ module TorqueBox
       end
 
       def on_message(hash)
-        FutureResponder.new( Queue.new( hash[:future_queue] ), hash[:future_id] ).respond do
+        FutureResponder.new( Queue.new( hash[:future_queue] ), hash[:future_id], hash[:future_ttl] ).respond do
           klass = hash[:receiver].class
           if klass.respond_to?( :__enable_backgroundable_newrelic_tracing )
             klass.__enable_backgroundable_newrelic_tracing( hash[:method] )

--- a/gems/messaging/lib/torquebox/messaging/future_responder.rb
+++ b/gems/messaging/lib/torquebox/messaging/future_responder.rb
@@ -28,10 +28,10 @@ module TorqueBox
       # @param [Integer] message_ttl The time-to-live used on messages
       #   to prevent them from staying in the queue indefinately if
       #   the result is never accessed.
-      def initialize(response_queue, correlation_id, message_ttl = 600_000)
+      def initialize(response_queue, correlation_id, message_ttl = nil)
         @queue = response_queue
         @correlation_id = correlation_id
-        @message_ttl = message_ttl
+        @message_ttl = message_ttl || 600_000
       end
 
       # Signal that processing has started.

--- a/gems/messaging/lib/torquebox/messaging/task.rb
+++ b/gems/messaging/lib/torquebox/messaging/task.rb
@@ -40,7 +40,8 @@ module TorqueBox
           :method => method,
           :payload => payload,
           :future_id => future.correlation_id,
-          :future_queue => queue_name
+          :future_queue => queue_name,
+          :future_ttl => options[:future_ttl]
         }
         options[:encoding] = :marshal
         queue.publish( message, options )
@@ -52,7 +53,7 @@ module TorqueBox
 
       def process!(message)
         hash = message.decode
-        FutureResponder.new( Queue.new( hash[:future_queue] ), hash[:future_id] ).respond do
+        FutureResponder.new( Queue.new( hash[:future_queue] ), hash[:future_id], hash[:future_ttl] ).respond do
           self.send hash[:method].to_sym, hash[:payload]
         end
       end

--- a/gems/messaging/spec/backgroundable_spec.rb
+++ b/gems/messaging/spec/backgroundable_spec.rb
@@ -176,6 +176,7 @@ describe TorqueBox::Messaging::Backgroundable do
                                              :future_id => '1234',
                                              :future_queue => "/queues/torquebox//tasks/torquebox_backgroundable",
                                              :method => '__sync_an_async_action',
+                                             :future_ttl => nil,
                                              :args => [:a, :b]
                                            },
                                            anything)
@@ -219,6 +220,16 @@ describe TorqueBox::Messaging::Backgroundable do
       it "should queue the args" do
         @queue.should_receive(:publish).with(hash_including(:args => [1,2]), anything)
         @object.background.foo(1,2)
+      end
+
+      it "should use default future ttl" do
+        @queue.should_receive(:publish).with(hash_including(:future_ttl => nil), anything)
+        @object.background.foo
+      end
+
+      it "should use custom future ttl" do
+        @queue.should_receive(:publish).with(hash_including(:future_ttl => 100_000), anything)
+        @object.background(:future_ttl => 100_000).foo
       end
 
       it "should raise when given a block" do
@@ -268,6 +279,16 @@ describe TorqueBox::Messaging::Backgroundable do
       it "should queue the args" do
         @queue.should_receive(:publish).with(hash_including(:args => [1,2]), anything)
         @object.background.foo(1,2)
+      end
+
+      it "should use default future ttl" do
+        @queue.should_receive(:publish).with(hash_including(:future_ttl => nil), anything)
+        @object.background.foo
+      end
+
+      it "should use custom future ttl" do
+        @queue.should_receive(:publish).with(hash_including(:future_ttl => 100_000), anything)
+        @object.background(:future_ttl => 100_000).foo
       end
 
       it "should raise when given a block" do

--- a/gems/messaging/spec/task_spec.rb
+++ b/gems/messaging/spec/task_spec.rb
@@ -29,10 +29,17 @@ describe TorqueBox::Messaging::Task do
     end
 
     it "should send payload correctly" do
-      expectation = [{:method => :payload=, :payload => {:foo => 'bar'}, :future_id => '1234', :future_queue => MyTestTask.queue_name('my_test')}, anything]
+      expectation = [{:method => :payload=, :payload => {:foo => 'bar'}, :future_id => '1234', :future_queue => MyTestTask.queue_name('my_test'), :future_ttl => nil}, anything]
       @send_queue.should_receive(:publish).with(*expectation)
       
       MyTestTask.async(:payload=, :foo => 'bar')
+    end
+
+    it "should send payload correctly with custom future ttl" do
+      expectation = [{:method => :payload=, :payload => {:foo => 'bar'}, :future_id => '1234', :future_queue => MyTestTask.queue_name('my_test'), :future_ttl => 10_000}, anything]
+      @send_queue.should_receive(:publish).with(*expectation)
+
+      MyTestTask.async(:payload=, {:foo => 'bar'}, {:future_ttl => 10_000})
     end
 
     it "should handle nil payload as empty hash" do

--- a/integration-tests/apps/rack/background/instance_methods_model.rb
+++ b/integration-tests/apps/rack/background/instance_methods_model.rb
@@ -3,7 +3,7 @@ require 'torquebox-messaging'
 class InstanceMethodsModel
   include TorqueBox::Messaging::Backgroundable
 
-  always_background :foo
+  always_background :foo, :future_ttl => 100_000
 
   def initialize
     @foreground = TorqueBox.fetch("queue/foreground")


### PR DESCRIPTION
This commit makes it possible to change the message ttl for the future
message.

Fixes https://issues.jboss.org/browse/TORQUE-959

Toby, if you were thinking about different implementation, let me know.
