### PR TITLE
Fixing missing line for documentation on clustering without multicast

### DIFF
--- a/docs/manual/en-US/src/main/docbook/production-setup.xml
+++ b/docs/manual/en-US/src/main/docbook/production-setup.xml
@@ -300,6 +300,7 @@ Listen 127.0.0.1:6666
     ...
     &lt;socket-binding name="jgroups-tcp" port="7600"/&gt;
     &lt;socket-binding name="jgroups-tcp-fd" port="57600"/&gt;
+    &lt;socket-binding name="jgroups-diagnostics" port="7500"/&gt;
     ...
   &lt;/socket-binding-group&gt;
 &lt;/server&gt;</programlisting>


### PR DESCRIPTION
Added an entry for 'jgroups-diagnostics' in socket-binding-group that was missing.
