### PR TITLE
[TORQUE-1090] TorqueBox.fetch uses javax.jms.Destination implementation instead of queue name in the TorqueBox::Messaging::Queue constructor

### DIFF
--- a/gems/messaging/lib/torquebox/messaging/destination.rb
+++ b/gems/messaging/lib/torquebox/messaging/destination.rb
@@ -28,6 +28,7 @@ module TorqueBox
 
       attr_reader :connection_factory
       attr_reader :name
+      attr_reader :java_destination
       attr_accessor :enumerable_options
       attr_accessor :connect_options
 
@@ -38,9 +39,8 @@ module TorqueBox
         :critical => 9
       }
 
-      def _dump(depth)
-        return self.name.queue_name if self.name.respond_to?( :queue_name )
-        self.name.to_s
+      def _dump(level)
+        to_s
       end
 
       def self._load(str)
@@ -63,7 +63,21 @@ module TorqueBox
           @connection_factory  = ConnectionFactory.new( connection_factory_or_options )
           @connect_options = {}
         end
-        @name                = destination
+
+
+        if destination.is_a?(javax.jms.Destination )
+          if destination.is_a?(javax.jms.Queue)
+            @name = destination.queue_name
+          else
+            @name = destination.topic_name
+          end
+
+          @java_destination = destination
+        else
+          @name = destination
+        end
+
+
         @enumerable_options  = {}
       end
 

--- a/gems/messaging/lib/torquebox/messaging/queue.rb
+++ b/gems/messaging/lib/torquebox/messaging/queue.rb
@@ -304,7 +304,7 @@ module TorqueBox
       # queue.
       def with_queue_control
         TorqueBox::ServiceRegistry.lookup("jboss.messaging.default") do |server|
-          yield server.management_service.get_resource("jms.queue.#{_dump(nil)}")
+          yield server.management_service.get_resource("jms.queue.#{@name}")
         end
       end
     end

--- a/gems/messaging/lib/torquebox/messaging/session.rb
+++ b/gems/messaging/lib/torquebox/messaging/session.rb
@@ -150,14 +150,9 @@ module TorqueBox
       end
       
       def java_destination(destination)
-        java_destination = destination.name
-        
-        unless java_destination.is_a?( javax.jms.Destination )
-          meth = destination.is_a?( Queue ) ? :create_queue : :create_topic
-          java_destination = @jms_session.send( meth, java_destination )
-        end
-        
-        java_destination
+        return destination.java_destination unless destination.java_destination.nil?
+        meth = destination.is_a?( Queue ) ? :create_queue : :create_topic
+        @jms_session.send( meth, destination.name )
       end
       
       def self.canonical_ack_mode(ack_mode)


### PR DESCRIPTION
Fixes the issue where TorqueBox.fetch sends wrong object as the first
argument of the constructor in TorqueBox::Messaging::Queue (and Topic)
class. It was an implementation of javax.jms.Destination interface, but
should be a simple String.
