### PR TITLE
TORQUE-1075 - Use service name in :inspect implementation

### DIFF
--- a/modules/services/src/main/java/org/torquebox/services/RubyService.java
+++ b/modules/services/src/main/java/org/torquebox/services/RubyService.java
@@ -75,7 +75,7 @@ public class RubyService implements RubyServiceMBean {
     }
 
     @Override
-    public String getStatus() throws Exception {
+    public String getStatus() {
         if (isStarted()) {
             return "STARTED";
         }
@@ -93,6 +93,20 @@ public class RubyService implements RubyServiceMBean {
     public ServiceComponent getComponent() {
         return this.servicesComponent;
     }
+
+    @Override
+    public String toString() {
+        return "[RubyService: name=" + this.name +
+                "; status=" + this.getStatus() + "]";
+    }
+
+    // Workaround for TORQUE-1075 - Use service name in :inspect implementation
+    // https://issues.jboss.org/browse/TORQUE-1075
+    @SuppressWarnings("unused")
+    public String inspect() {
+        return this.toString();
+    }
+
 
     private String name;
     private boolean started;

--- a/modules/services/src/main/java/org/torquebox/services/RubyServiceMBean.java
+++ b/modules/services/src/main/java/org/torquebox/services/RubyServiceMBean.java
@@ -28,6 +28,6 @@ public interface RubyServiceMBean {
     
     String getName();
     String getRubyClassName();
-    String getStatus() throws Exception;
+    String getStatus();
 
 }


### PR DESCRIPTION
It was fixed by implementing the inspect method in the service, since
JRuby did not a good job at creating the object inspection on its own.

Fixes: https://issues.jboss.org/browse/TORQUE-1075
