### PR TITLE
Fix Torquebox::Cache when Infinispan is not available

### DIFF
--- a/gems/cache/lib/torquebox/cache.rb
+++ b/gems/cache/lib/torquebox/cache.rb
@@ -53,11 +53,14 @@ module TorqueBox
       end
 
       def initialize(opts = {})
-        return nothing unless INFINISPAN_AVAILABLE
         @options = opts
-        options[:transaction_mode] = :transactional unless options.has_key?( :transaction_mode )
-        options[:locking_mode] ||= :optimistic if (transactional? && !options.has_key?( :locking_mode ))
-        options[:sync] = true if options[:sync].nil?
+        
+        if INFINISPAN_AVAILABLE
+          options[:transaction_mode] = :transactional unless options.has_key?( :transaction_mode )
+          options[:locking_mode] ||= :optimistic if (transactional? && !options.has_key?( :locking_mode ))
+          options[:sync] = true if options[:sync].nil?
+        end
+
         if options[:encoding] == :marshal
           log( "Encoding of :marshal cannot be used with " +
                "TorqueBox::Infinispan::Cache - using :marshal_base64 instead",


### PR DESCRIPTION
After upgrading to TorqueBox 3.0.0, I kept getting the following error in development:

```
NoMethodError (undefined method `encode' for nil:NilClass)
/torquebox-cache-3.0.0-java/lib/torquebox/cache.rb:260:in `encode'
/torquebox-cache-3.0.0-java/lib/torquebox/cache.rb:163:in `get'
/torquebox-cache-3.0.0-java/lib/active_support/cache/torque_box_store.rb:100:in `read_entry'
```

It turns out this was caused by not running in TorqueBox, and hence Infinispan was not available. When this happens, no instance variables are ever set and none of the methods that rely on `@codec` (such as `#encode`) work either.
