### PR TITLE
Use rackup script file for Rails 2 applications, if it exists

### DIFF
--- a/modules/web/src/main/java/org/torquebox/web/rails/RailsRackProcessor.java
+++ b/modules/web/src/main/java/org/torquebox/web/rails/RailsRackProcessor.java
@@ -26,6 +26,8 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.torquebox.core.app.RubyAppMetaData;
 import org.torquebox.web.rack.RackMetaData;
 
+import java.io.File;
+
 public class RailsRackProcessor implements DeploymentUnitProcessor {
 
     @Override
@@ -41,7 +43,11 @@ public class RailsRackProcessor implements DeploymentUnitProcessor {
         }
         
         if (!railsAppMetaData.isRails3()) {
-            rackAppMetaData.setRackUpScript( getRackUpScript( rackAppMetaData.getContextPath() ) );
+            File root = rubyAppMetaData.getRoot();
+            File rackup = rackAppMetaData.getRackUpScriptFile(root);
+            if (!rackup.exists()) {
+                rackAppMetaData.setRackUpScript( getRackUpScript( rackAppMetaData.getContextPath() ) );
+            }
         }
     }
     


### PR DESCRIPTION
This pull request disables the automatic generation of a rackup script files for Rails 2 applications that already have one. While config.ru files aren't used by default in Rails 2, they are supported, and some gems like sprockets require it.
