### PR TITLE
add precompile_assets option to archive task

### DIFF
--- a/gems/rake-support/lib/torquebox/rake/tasks/archive.rb
+++ b/gems/rake-support/lib/torquebox/rake/tasks/archive.rb
@@ -21,7 +21,7 @@ require 'torquebox/deploy_utils'
 namespace :torquebox do
 
   desc "Create a nice self-contained application archive"
-  task :archive, :name do |t, args|
+  task :archive, [:name, :precompile_assets] do |t, args|
     path = TorqueBox::DeployUtils.create_archive( args )
     puts "Created archive: #{path}"
   end


### PR DESCRIPTION
The `Torquebox::DeployUtils.create_archive` method checks the `opts` argument for several keys that aren't being used in the `:archive` rake task. This change utilizes the `precompile_assets` option to allow asset compilation during the creation of the archive similar to the flag `--precompile_assets` for `torquebox archive ROOT`.
