### PR TITLE
Fix SessionData so it's fetch method works like the ruby Hash#fetch meth...

### DIFF
--- a/gems/web/lib/torquebox/session/servlet_store.rb
+++ b/gems/web/lib/torquebox/session/servlet_store.rb
@@ -134,7 +134,10 @@ module TorqueBox
       def [](key)
         super(key.to_s)
       end
-      alias :fetch :[]
+      
+      def fetch(key, *args, &block)
+        super(key.to_s, *args, &block)
+      end
 
       def has_key?(key)
         super(key.to_s)


### PR DESCRIPTION
...od
# fetch was aliased to [] which makes that method incompatible with how the method works on a ruby Hash.

This fixes https://issues.jboss.org/browse/TORQUE-1173
