### PR TITLE
added error info for better explanation

### DIFF
--- a/gems/capistrano-support/lib/torquebox/capistrano/recipes.rb
+++ b/gems/capistrano-support/lib/torquebox/capistrano/recipes.rb
@@ -211,8 +211,8 @@ module Capistrano
   end
 end
 
-
-if Capistrano::Configuration.instance
+unless Capistrano::Configuration.respond_to?(:instance)
+  abort "capistrano/ext/multistage is required, just make sure you are using Capistrano 2"
+else
   Capistrano::TorqueBox.load_into(Capistrano::Configuration.instance)
 end
-


### PR DESCRIPTION
Fixed/Added error info when you run `$ jruby -S cap deploy production`:

```
cap aborted!
undefined method `instance' for Capistrano::Configuration:Class
/home/surya/.rvm/gems/jruby-1.7.6/gems/torquebox-capistrano-support-3.0.1/lib/torquebox/capistrano/recipes.rb:215:in `(root)'
org/jruby/RubyKernel.java:1082:in `require'
/home/surya/.rvm/gems/jruby-1.7.6/gems/torquebox-capistrano-support-3.0.1/lib/torquebox-capistrano-support.rb:1:in `(root)'
org/jruby/RubyKernel.java:1082:in `require'
/home/surya/.rvm/gems/jruby-1.7.6/gems/torquebox-capistrano-support-3.0.1/lib/torquebox-capistrano-support.rb:18:in `(root)'
org/jruby/RubyKernel.java:1101:in `load'
/home/surya/Desktop/surya/work/codes/projects/job/resolutions/Capfile:1:in `(root)'
/home/surya/Desktop/surya/work/codes/projects/job/resolutions/Capfile:27:in `(root)'
/home/surya/.rvm/gems/jruby-1.7.6/gems/capistrano-3.0.1/lib/capistrano/application.rb:22:in `load_rakefile'
org/jruby/RubyKernel.java:1101:in `load'
/home/surya/.rvm/gems/jruby-1.7.6/bin/cap:23:in `(root)'
```
