### PR TITLE
[Torquebox4] Get rid of bundler inside jar

### DIFF
--- a/core/lib/torquebox/cli/jar.rb
+++ b/core/lib/torquebox/cli/jar.rb
@@ -69,7 +69,7 @@ module TorqueBox
 language=ruby
 extract_paths=app/:jruby/
 root=${extract_root}/app
-init=require "bundler/setup"; \
+init=require "vendor/bundle/bundler/setup"; \
 require "torquebox-web"; \
 if org.projectodd.wunderboss.WunderBoss.options.get("wildfly-service").nil?; \
   begin; \
@@ -148,12 +148,7 @@ EOS
         lockfile = Bundler.default_lockfile
         FileUtils.cp(gemfile, "#{tmpdir}/Gemfile")
         FileUtils.cp(lockfile, "#{tmpdir}/Gemfile.lock")
-        eval_in_new_ruby <<-EOS
-          Dir.chdir('#{tmpdir}')
-          require 'bundler/cli'
-          Bundler::CLI.start(['cache', '--all'])
-        EOS
-        install_options = %w(--local --path vendor/bundle --no-cache)
+        install_options = %w(--standalone --path vendor/bundle)
         unless bundle_without.empty?
           install_options += %W(--without #{bundle_without.join(' ')})
         end
@@ -167,12 +162,6 @@ EOS
                   :pattern => "/{**/*,.bundle/**/*}",
                   :jar_prefix => "app",
                   :exclude => TorqueBox::Jars.list.map { |j| File.basename(j)  })
-        Gem.default_path.each do |prefix|
-          add_files(jar_builder,
-                    :file_prefix => prefix,
-                    :pattern => "/**/bundler-#{Bundler::VERSION}{*,/**/*}",
-                    :jar_prefix => "jruby/lib/ruby/gems/shared")
-        end
       end
 
       def add_torquebox_files(jar_builder)


### PR DESCRIPTION
At first. Huge thank you for this feature! This is what I wanted for years in ruby ecosystem.

But I can't make it work as is.

```
 java -jar api.jar
01:37:36,523 [INFO ] org.projectodd.wunderboss  - Initializing application as ruby
Could not find rake-10.3.2 in any of the sources
Run `bundle install` to install missing gems.
Exception in thread "main" org.jruby.exceptions.RaiseException: (SystemExit) exit
    at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:877)
    at org.jruby.RubyKernel.exit(org/jruby/RubyKernel.java:840)
    at RUBY.(root)(/var/folders/28/_36t5qdj65x37562tngrt_8m0000gp/T/wunderboss518836244026180736/jruby/lib/ruby/gems/shared/gems/bundler-1.6.2/lib/bundler/setup.rb:14)
    at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:1065)
    at RUBY.(root)(/var/folders/28/_36t5qdj65x37562tngrt_8m0000gp/T/wunderboss518836244026180736/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1)
    at RUBY.require(/var/folders/28/_36t5qdj65x37562tngrt_8m0000gp/T/wunderboss518836244026180736/jruby/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:135)
```

When I googled for solution I found `--standalone` option which makes a bundle that can work without the Bundler runtime. This is another approach, but it works for me. No bundler, no such issues at all.
