### PR TITLE
Fix header key case in fillKey

### DIFF
--- a/web/ext/wunderboss-rack/org/projectodd/wunderboss/rack/RackEnvironmentHash.java
+++ b/web/ext/wunderboss-rack/org/projectodd/wunderboss/rack/RackEnvironmentHash.java
@@ -61,9 +61,9 @@ public class RackEnvironmentHash extends RubyHash {
                 if (keyBytes.length > 5 && keyBytes[0] == 'H'
                         && keyBytes[1] == 'T' && keyBytes[2] == 'T'
                         && keyBytes[3] == 'P' && keyBytes[4] == '_') {
-                    // this HttpString ctor has misleading variable names -
-                    // it's a copy from/to, not offset/length
-                    HttpString httpString = new HttpString(keyBytes, 5, keyBytes.length);
+
+                    String key = new String(keyBytes, 5, keyBytes.length - 5);
+                    HttpString httpString = new HttpString(toCamelCase(key));
                     fillHeaderKey(httpString, keyBytes);
                 } else {
                     fillRackKey((RubyString) rubyKey);
@@ -174,6 +174,24 @@ public class RackEnvironmentHash extends RubyHash {
             c -= 32;
         }
         return c;
+    }
+
+    public static String toCamelCase(final String init) {
+        if (init==null) {
+            return null;
+        }
+        final StringBuilder ret = new StringBuilder(init.length());
+        for (final String word : init.split("_")) {
+            if (!word.isEmpty()) {
+                ret.append(toUpperCase(word.charAt(0)));
+                ret.append(word.substring(1).toLowerCase());
+            }
+            if (!(ret.length()==init.length())) {
+                ret.append("-");
+            }
+        }
+
+        return ret.toString();
     }
 
     private static String getRemoteAddr(final HttpServerExchange exchange) {


### PR DESCRIPTION
The problem is that [`headers`](https://github.com/etehtsea/torquebox/blob/fc253afd8268de1827bebb7e4808ecf1e9be47e8/web/ext/wunderboss-rack/org/projectodd/wunderboss/rack/RackEnvironmentHash.java#L137) contains camelcased keys, but `rubyKey` is upcased.

```
[5] pry(#<Rack::Builder>)> env['HTTP_USER_AGENT']
=> nil
[6] pry(#<Rack::Builder>)> env.to_s
=> "{\"SERVER_NAME\"=>\"0.0.0.0\", \"HTTP_ACCEPT\"=>\"*/*\", \"rack.multithread\"=>true, \"rack.url_scheme\"=>\"http\", \"rack.multiprocess\"=>true, \"rack.input\"=>#<WunderBoss::RackChannel:0x74fd7616>, \"rack.errors\"=>#<IO:fd 562>, \"CONTENT_TYPE\"=>\"null\", \"REQUEST_URI\"=>\"/\", \"rack.version\"=>[1, 1], \"SERVER_PORT\"=>\"9292\", \"REQUEST_METHOD\"=>\"GET\", \"REMOTE_ADDR\"=>\"127.0.0.1\", \"rack.run_once\"=>false, \"PATH_INFO\"=>\"/\", \"SCRIPT_NAME\"=>\"\", \"QUERY_STRING\"=>\"\", \"HTTP_USER_AGENT\"=>\"curl/7.30.0\", \"HTTP_HOST\"=>\"0.0.0.0:9292\"}"
```

P.S. I'm not sure about the best way to fix this issue. I'm not a Java-guy to be honest.
