### PR TITLE
stringify http header values

### DIFF
--- a/web/lib/wunderboss_rack_response_handler.rb
+++ b/web/lib/wunderboss_rack_response_handler.rb
@@ -25,7 +25,7 @@ module WunderBoss
 
           transfer_encoding_value = nil
           headers.each do |key, value|
-            rack_responder.add_header(key, value)
+            rack_responder.add_header(key, value.to_s)
             transfer_encoding_value = value if key == 'Transfer-Encoding'
           end
 


### PR DESCRIPTION
Don't know if it's intentional but HTTP response headers are no longer converted to strings as it used to be in version 3, at least.
