### PR TITLE
Improve access to TorqueBox::Logger

### DIFF
--- a/core/lib/torquebox/logger.rb
+++ b/core/lib/torquebox/logger.rb
@@ -90,6 +90,10 @@ module TorqueBox
     def flush
     end
 
+    def level
+      (@logger.level || @logger.effective_level).to_s
+    end
+
     private
 
     def add(severity, *params)

--- a/core/lib/torquebox/logger.rb
+++ b/core/lib/torquebox/logger.rb
@@ -22,6 +22,63 @@ module TorqueBox
         @log_level = level
         org.projectodd.wunderboss.WunderBoss.log_level = level
       end
+
+      def logger
+        @logger ||= new
+      end
     end
+
+    def initialize(name = nil)
+      @logger = org.projectodd.wunderboss.WunderBoss.logger(name || 'TorqueBox')
+    end
+
+    def trace?
+      @logger.trace_enabled?
+    end
+
+    def debug?
+      @logger.debug_enabled?
+    end
+
+    def info?
+      @logger.info_enabled?
+    end
+
+    def warn?
+      @logger.warn_enabled?
+    end
+
+    def error?
+      @logger.error_enabled?
+    end
+    alias_method :fatal?, :error?
+
+    [:trace, :debug, :info, :warn, :error].each do |severity|
+      define_method(severity) do |*params, &block|
+        add(severity, *params, &block)
+      end
+    end
+    alias_method :fatal, :error
+
+    # Allow our logger to be used for env['rack.errors']
+    def puts(message)
+      info message.to_s
+    end
+
+    def write(message)
+      info message.strip
+    end
+
+    def flush
+    end
+
+    private
+
+    def add(severity, *params)
+      message = block_given? ? yield : params.shift
+
+      @logger.send(severity, message, *params)
+    end
+
   end
 end

--- a/core/lib/torquebox/logger.rb
+++ b/core/lib/torquebox/logger.rb
@@ -57,51 +57,121 @@ module TorqueBox
 
     attr_accessor :formatter
 
+    # Wraps a WunderBoss logger
+    #
+    # @param name [Object] Name for the logger
     def initialize(name = DEFAULT_CATEGORY)
       @logger = WunderBoss.logger(name.to_s.gsub('::', '.'))
     end
 
+    # Reports if TRACE level is enabled
+    #
+    # @return [true, false] true if TRACE is enabled
     def trace?
       @logger.trace_enabled?
     end
 
+    # Reports if DEBUG level is enabled
+    #
+    # @return [true, false] true if DEBUG is enabled
     def debug?
       @logger.debug_enabled?
     end
 
+    # Reports if INFO level is enabled
+    #
+    # @return [true, false] true if INFO is enabled
     def info?
       @logger.info_enabled?
     end
 
+    # Reports if WARN level is enabled
+    #
+    # @return [true, false] true if WARN is enabled
     def warn?
       @logger.warn_enabled?
     end
 
+    # Reports if ERROR level is enabled
+    #
+    # @return [true, false] true if ERROR is enabled
     def error?
       @logger.error_enabled?
     end
+
+    # @!method fatal?()
+    #
+    # Reports if FATAL level is enabled
+    #
+    # @return [true, false] true if FATAL is enabled
     alias_method :fatal?, :error?
 
+    # Logs a message at the TRACE level
+    #
+    # @param message [String] the message to log
+    # @return [void]
     def trace(*params, &block)
       add(:trace, *params, &block)
     end
 
+    # Logs a message at the DEBUG level
+    #
+    # @param message [String] the message to log
+    # @return [void]
     def debug(*params, &block)
       add(:debug, *params, &block)
     end
 
+    # Logs a message at the INFO level
+    #
+    # @param message [String] the message to log
+    # @return [void]
     def info(*params, &block)
       add(:info, *params, &block)
     end
 
+    # Logs a message at the WARN level
+    #
+    # @param message [String] the message to log
+    # @return [void]
     def warn(*params, &block)
       add(:warn, *params, &block)
     end
 
+    # Logs a message at the ERROR level
+    #
+    # @param message [String] the message to log
+    # @return [void]
     def error(*params, &block)
       add(:error, *params, &block)
     end
+
+    # @!method fatal?()
+    #
+    # Logs a message at the FATAL level
+    #
+    # @param message [String] the message to log
+    # @return [void]
     alias_method :fatal, :error
+
+    # Reports current logger's level
+    #
+    # @return [String] log level
+    def level
+      (@logger.level || @logger.effective_level).to_s
+    end
+
+    # Sets current logger's level
+    #
+    # @params [String] log level
+    # @returns [String] log level
+    def level=(new_level)
+      if new_level.respond_to?(:to_int)
+        new_level = STD_LOGGER_LEVELS[new_level]
+      end
+
+      LogbackUtil.set_log_level(@logger, new_level)
+    end
 
     # Allow our logger to be used for env['rack.errors']
     def puts(message)
@@ -112,20 +182,7 @@ module TorqueBox
       info message.strip
     end
 
-    def flush
-    end
-
-    def level
-      (@logger.level || @logger.effective_level).to_s
-    end
-
-    def level=(new_level)
-      if new_level.respond_to?(:to_int)
-        new_level = STD_LOGGER_LEVELS[new_level]
-      end
-
-      LogbackUtil.set_log_level(@logger, new_level)
-    end
+    def flush; end
 
     private
 
@@ -133,6 +190,5 @@ module TorqueBox
       message = block_given? ? yield : params.shift
       @logger.send(severity, message, *params)
     end
-
   end
 end

--- a/core/lib/torquebox/logger.rb
+++ b/core/lib/torquebox/logger.rb
@@ -15,6 +15,9 @@
 
 module TorqueBox
   class Logger
+
+    DEFAULT_CATEGORY = 'TorqueBox'.freeze
+
     class << self
       attr_reader :log_level
 
@@ -29,7 +32,8 @@ module TorqueBox
     end
 
     def initialize(name = nil)
-      @logger = org.projectodd.wunderboss.WunderBoss.logger(name || 'TorqueBox')
+      category = name || DEFAULT_CATEGORY
+      @logger = org.projectodd.wunderboss.WunderBoss.logger(category.to_s.gsub('::', '.'))
     end
 
     def trace?
@@ -76,7 +80,6 @@ module TorqueBox
 
     def add(severity, *params)
       message = block_given? ? yield : params.shift
-
       @logger.send(severity, message, *params)
     end
 

--- a/core/lib/torquebox/logger.rb
+++ b/core/lib/torquebox/logger.rb
@@ -57,10 +57,24 @@ module TorqueBox
     end
     alias_method :fatal?, :error?
 
-    [:trace, :debug, :info, :warn, :error].each do |severity|
-      define_method(severity) do |*params, &block|
-        add(severity, *params, &block)
-      end
+    def trace(*params, &block)
+      add(:trace, *params, &block)
+    end
+
+    def debug(*params, &block)
+      add(:debug, *params, &block)
+    end
+
+    def info(*params, &block)
+      add(:info, *params, &block)
+    end
+
+    def warn(*params, &block)
+      add(:warn, *params, &block)
+    end
+
+    def error(*params, &block)
+      add(:error, *params, &block)
     end
     alias_method :fatal, :error
 

--- a/core/spec/logger_spec.rb
+++ b/core/spec/logger_spec.rb
@@ -79,6 +79,26 @@ describe TorqueBox::Logger do
     end
   end
 
+  context "configuration" do
+    it "should have a context" do
+      TorqueBox::Logger.context.should be_a(Java::ChQosLogbackClassic::LoggerContext)
+    end
+
+    it "should allow configuration by an XML File" do
+      TorqueBox::Logger.configure_with_xml(File.join(File.dirname(__FILE__), '..', 'lib', 'resources', 'logback-cli.xml'))
+    end
+
+    it "should allow configuration by an XML String" do
+      TorqueBox::Logger.configure_with_xml(<<-XML
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <root level="OFF"/>
+</configuration>
+        XML
+      )
+    end
+  end
+
   context "torquebox 3 specs" do
     it "should look nice for class objects" do
       logger = TorqueBox::Logger.new(Foo::Bar)
@@ -108,11 +128,6 @@ describe TorqueBox::Logger do
       logger.should respond_to(:puts)
       logger.should respond_to(:write)
       logger.should respond_to(:flush)
-    end
-
-    it "should have a formatter" do
-      logger.should respond_to(:formatter)
-      logger.formatter.should_not be_nil
     end
   end
 end

--- a/core/spec/logger_spec.rb
+++ b/core/spec/logger_spec.rb
@@ -59,6 +59,16 @@ describe TorqueBox::Logger do
     end
   end
 
+  context "log levels" do
+    it "should respect global log level" do
+      TorqueBox::Logger.log_level = 'WARN'
+      logger = TorqueBox::Logger.new
+      logger.level.should == 'WARN'
+      logger.info?.should be_falsey
+      logger.warn?.should be_truthy
+    end
+  end
+
   context "torquebox 3 specs" do
     it "should look nice for class objects" do
       logger = TorqueBox::Logger.new(Foo::Bar)
@@ -74,11 +84,11 @@ describe TorqueBox::Logger do
       logger.should respond_to(:fatal?)
     end
 
-    it "should not barf on meaningless level setting" do
-      skip
-      logger.level = Logger::WARN
-      logger.level.should == Logger::WARN
-    end
+    # it "should not barf on meaningless level setting" do
+    #   skip
+    #   logger.level = Logger::WARN
+    #   logger.level.should == Logger::WARN
+    # end
 
     it "should deal with blocks correctly" do
       logger.error "JC: message zero"
@@ -96,10 +106,10 @@ describe TorqueBox::Logger do
       logger.should respond_to(:flush)
     end
 
-    it "should have a formatter" do
-      skip
-      logger.should respond_to(:formatter)
-      logger.formatter.should_not be_nil
-    end
+    # it "should have a formatter" do
+    #   skip
+    #   logger.should respond_to(:formatter)
+    #   logger.formatter.should_not be_nil
+    # end
   end
 end

--- a/core/spec/logger_spec.rb
+++ b/core/spec/logger_spec.rb
@@ -14,6 +14,11 @@
 
 require 'spec_helper'
 
+module Foo
+  class Bar
+  end
+end
+
 describe TorqueBox::Logger do
 
   let(:logger) { TorqueBox::Logger.new }
@@ -55,11 +60,10 @@ describe TorqueBox::Logger do
   end
 
   context "torquebox 3 specs" do
-    # it "should look nice for class objects" do
-    #   require 'torquebox/service_registry'
-    #   logger = TorqueBox::Logger.new(TorqueBox::ServiceRegistry)
-    #   logger.error("JC: log for cache store")
-    # end
+    it "should look nice for class objects" do
+      logger = TorqueBox::Logger.new(Foo::Bar)
+      logger.error("JC: log for cache store")
+    end
 
     it "should support the various boolean methods" do
       logger.should respond_to(:trace?)
@@ -70,10 +74,11 @@ describe TorqueBox::Logger do
       logger.should respond_to(:fatal?)
     end
 
-    # it "should not barf on meaningless level setting" do
-    #   logger.level = Logger::WARN
-    #   logger.level.should == Logger::WARN
-    # end
+    it "should not barf on meaningless level setting" do
+      skip
+      logger.level = Logger::WARN
+      logger.level.should == Logger::WARN
+    end
 
     it "should deal with blocks correctly" do
       logger.error "JC: message zero"
@@ -91,9 +96,10 @@ describe TorqueBox::Logger do
       logger.should respond_to(:flush)
     end
 
-    # it "should have a formatter" do
-    #   logger.should respond_to(:formatter)
-    #   logger.formatter.should_not be_nil
-    # end
+    it "should have a formatter" do
+      skip
+      logger.should respond_to(:formatter)
+      logger.formatter.should_not be_nil
+    end
   end
 end

--- a/core/spec/logger_spec.rb
+++ b/core/spec/logger_spec.rb
@@ -1,0 +1,99 @@
+# Copyright 2014 Red Hat, Inc, and individual contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe TorqueBox::Logger do
+
+  let(:logger) { TorqueBox::Logger.new }
+
+  context "simple logging" do
+    it "should log trace" do
+      logger.trace("foo")
+    end
+
+    it "should log debug" do
+      logger.debug("foo")
+    end
+
+    it "should log info" do
+      logger.info("foo")
+    end
+
+    it "should log warn" do
+      logger.warn("foo")
+    end
+
+    it "should log error" do
+      logger.error("foo")
+    end
+
+    it "should log fatal" do
+      logger.fatal("foo")
+    end
+  end
+
+  context "parameterized logging" do
+    it "should format one parameter" do
+      logger.info("foo {}", "bar")
+    end
+
+    it "should format two parameters" do
+      logger.info("foo {} {}", "bar", "baz")
+    end
+  end
+
+  context "torquebox 3 specs" do
+    # it "should look nice for class objects" do
+    #   require 'torquebox/service_registry'
+    #   logger = TorqueBox::Logger.new(TorqueBox::ServiceRegistry)
+    #   logger.error("JC: log for cache store")
+    # end
+
+    it "should support the various boolean methods" do
+      logger.should respond_to(:trace?)
+      logger.should respond_to(:debug?)
+      logger.should respond_to(:info?)
+      logger.should respond_to(:warn?)
+      logger.should respond_to(:error?)
+      logger.should respond_to(:fatal?)
+    end
+
+    # it "should not barf on meaningless level setting" do
+    #   logger.level = Logger::WARN
+    #   logger.level.should == Logger::WARN
+    # end
+
+    it "should deal with blocks correctly" do
+      logger.error "JC: message zero"
+      logger.error { "JC: message" }
+      logger.error "JC: message too"
+    end
+
+    it "should handle nil parameters" do
+      logger.info(nil)
+    end
+
+    it "should support the rack.errors interface" do
+      logger.should respond_to(:puts)
+      logger.should respond_to(:write)
+      logger.should respond_to(:flush)
+    end
+
+    # it "should have a formatter" do
+    #   logger.should respond_to(:formatter)
+    #   logger.formatter.should_not be_nil
+    # end
+  end
+end

--- a/core/spec/logger_spec.rb
+++ b/core/spec/logger_spec.rb
@@ -85,7 +85,9 @@ describe TorqueBox::Logger do
     end
 
     it "should allow configuration by an XML File" do
-      TorqueBox::Logger.configure_with_xml(File.join(File.dirname(__FILE__), '..', 'lib', 'resources', 'logback-cli.xml'))
+      TorqueBox::Logger.configure_with_xml(File.join(
+        File.dirname(__FILE__), '..', 'lib', 'resources', 'logback-cli.xml')
+      )
     end
 
     it "should allow configuration by an XML String" do

--- a/core/spec/logger_spec.rb
+++ b/core/spec/logger_spec.rb
@@ -67,6 +67,16 @@ describe TorqueBox::Logger do
       logger.info?.should be_falsey
       logger.warn?.should be_truthy
     end
+
+    it "should set levels with a string" do
+      logger.level = 'WARN'
+      logger.level.should == 'WARN'
+    end
+
+    it "should set levels with a ruby log level" do
+      logger.level = ::Logger::WARN
+      logger.level.should == 'WARN'
+    end
   end
 
   context "torquebox 3 specs" do
@@ -84,12 +94,6 @@ describe TorqueBox::Logger do
       logger.should respond_to(:fatal?)
     end
 
-    # it "should not barf on meaningless level setting" do
-    #   skip
-    #   logger.level = Logger::WARN
-    #   logger.level.should == Logger::WARN
-    # end
-
     it "should deal with blocks correctly" do
       logger.error "JC: message zero"
       logger.error { "JC: message" }
@@ -106,10 +110,9 @@ describe TorqueBox::Logger do
       logger.should respond_to(:flush)
     end
 
-    # it "should have a formatter" do
-    #   skip
-    #   logger.should respond_to(:formatter)
-    #   logger.formatter.should_not be_nil
-    # end
+    it "should have a formatter" do
+      logger.should respond_to(:formatter)
+      logger.formatter.should_not be_nil
+    end
   end
 end


### PR DESCRIPTION
This PR is still somewhat of a work-in-progress, though I was hoping to get some eyes on it for feedback. Basic stdlib-style logging support is included in this PR.

Caveats
-----------
Ruby stdlib Logger supports a block form to ensure that expensive log messages are only calculated if the log level constraint is met, saving potentially unnecessary work:
```
logger.info { "Entry number #{i} is: #{entries[i]}" }
```

Logback, on the other hand uses parameterized logging to fulfill the same function: http://logback.qos.ch/manual/architecture.html#parametrized

I favored Logback's as I don't think that log level checking should be handled both in Ruby and Java spaces.

TODO
--------
* ~~Rectify Logger::Severity differenes with Logback's Log levels~~
* ~~Ensure Log levels actually are enforced as expected~~
* Ensure this is compatible with "typical" logging front ends like Rail's TaggedLogger.
* Support Logback Formatters

