### PR TITLE
Support file/directory exclusion from jar and war files.

### DIFF
--- a/core/lib/torquebox/cli/jar.rb
+++ b/core/lib/torquebox/cli/jar.rb
@@ -86,6 +86,12 @@ end;"
            :name => :main,
            :switch => '--main MAIN',
            :description => 'File to require to bootstrap the application (if not given, assumes a web app)'
+         },
+         {
+           :name => :exclude,
+           :switch => '--exclude EXCLUDES',
+           :description => 'File paths to exclude from bundled jar',
+           :type => Array
          }]
       end
 
@@ -128,7 +134,7 @@ end;"
           add_jruby_files(jar_builder)
         end
 
-        add_app_files(jar_builder)
+        add_app_files(jar_builder, options)
 
         if options[:bundle_gems]
           tmpdir = Dir.mktmpdir("tmptorqueboxjar", ".")
@@ -168,13 +174,17 @@ end;"
         add_jar(jar_builder, "#{rb_config['libdir']}/jruby.jar")
       end
 
-      def add_app_files(jar_builder)
+      def add_app_files(jar_builder, options)
         @logger.trace("Adding application files to jar...")
+        exclude = [%r{^/[^/]*\.(jar|war)}]
+        if options[:exclude]
+          exclude = exclude + options[:exclude].map { |e| Regexp.new("^#{e}") }
+        end
         add_files(jar_builder,
                   :file_prefix => Dir.pwd,
                   :pattern => "/**/*",
                   :jar_prefix => "app",
-                  :exclude => [%r{^/[^/]*\.(jar|war)}])
+                  :exclude => exclude)
       end
 
       def add_bundler_files(jar_builder, tmpdir, bundle_without)

--- a/core/lib/torquebox/cli/jar.rb
+++ b/core/lib/torquebox/cli/jar.rb
@@ -178,7 +178,7 @@ end;"
         @logger.trace("Adding application files to jar...")
         exclude = [%r{^/[^/]*\.(jar|war)}]
         if options[:exclude]
-          exclude = exclude + options[:exclude].map { |e| Regexp.new("^#{e}") }
+          exclude += options[:exclude].map { |e| Regexp.new("^#{e}") }
         end
         add_files(jar_builder,
                   :file_prefix => Dir.pwd,

--- a/core/spec/jar_cli_spec.rb
+++ b/core/spec/jar_cli_spec.rb
@@ -44,4 +44,17 @@ describe TorqueBox::CLI::Jar do
     expect(File.exist?(lockfile)).to be false
   end
 
+  it "doesn't include excluded paths" do
+    Dir.chdir(@tmpdir) do
+      File.new("excludeme", "w")
+      Dir.mkdir("includeme")
+      File.new("includeme/excludeme", "w")
+      TorqueBox::CLI.new(%W(jar --exclude /excludeme -q --no-include-jruby --no-bundle-gems --name test.jar))
+      File.exist?("test.jar").should == true
+      unzip("test.jar")
+      File.exist?("app/excludeme").should == false
+      File.exist?("app/includeme/excludeme").should == true
+    end
+  end
+
 end


### PR DESCRIPTION
This PR adds an --exclude param to allow for multiple path exclusions. Currently it supports a relative path from the application's root, but could easily be changed to support regexp patterns.