### PR TITLE
Fix --exclude

### DIFF
--- a/core/lib/torquebox/cli/jar.rb
+++ b/core/lib/torquebox/cli/jar.rb
@@ -285,7 +285,7 @@ module TorqueBox
       def add_files(jar_builder, options)
         prefix = options[:file_prefix]
         prefix += '/' unless prefix.end_with?('/')
-        Dir.glob("#{prefix}#{options[:pattern]}").each do |file|
+        Dir.glob(File.join(prefix, options[:pattern])).each do |file|
           suffix = file.sub(prefix, '')
           excludes = [options[:exclude]].compact.flatten
           next if excludes.any? do |exclude|


### PR DESCRIPTION
If `options[:pattern]` has a leading slash, each file path in the glob
would have a double slash, causing the suffix to have a leading slash.
This leading slash is unexpected, as users want to pass options like
`--exclude foo`, not `--exclude /foo`.

This works because `File.join("foo/", "/bar") == "foo/bar"`.