### PR TITLE
Add logic to precompile assets when building JARs

### DIFF
--- a/core/lib/torquebox-core.rb
+++ b/core/lib/torquebox-core.rb
@@ -58,6 +58,7 @@ end
 TorqueBox::Jars.register_and_require("#{File.dirname(__FILE__)}/torquebox-core.jar")
 require 'torquebox/cli'
 require 'torquebox/cli/archive'
+require 'torquebox/cli/shell_command'
 require 'torquebox/cli/jar'
 require 'torquebox/cli/war'
 require 'torquebox/daemon'

--- a/core/lib/torquebox/cli/jar.rb
+++ b/core/lib/torquebox/cli/jar.rb
@@ -39,6 +39,7 @@ module TorqueBox
           :destination => '.',
           :jar_name => "#{File.basename(Dir.pwd)}.jar",
           :include_jruby => true,
+          :precompile_assets => true,
           :bundle_gems => true,
           :bundle_without => %W(development test assets),
           :rackup => 'config.ru'
@@ -61,6 +62,11 @@ module TorqueBox
            :name => :include_jruby,
            :switch => '--[no-]include-jruby',
            :description => "Include JRuby in the jar (default: #{defaults[:include_jruby]})"
+         },
+         {
+           :name => :precompile_assets,
+           :switch => '--[no-]precompile-assets',
+           :description => "Precompile rails assets for the jar (default: #{defaults[:precompile_assets]})"
          },
          {
            :name => :bundle_gems,
@@ -125,6 +131,10 @@ module TorqueBox
           add_jruby_files(jar_builder)
         end
 
+        if options[:precompile_assets]
+          precompile_assets
+        end
+
         add_app_files(jar_builder, options)
 
         if options[:bundle_gems]
@@ -163,6 +173,12 @@ module TorqueBox
                   :pattern => "/*",
                   :jar_prefix => "jruby/bin")
         add_jar(jar_builder, "#{rb_config['libdir']}/jruby.jar")
+      end
+
+      def precompile_assets
+        @logger.info 'Precompiling assets'
+        command = jruby_command 'bundle exec rake assets:precompile'
+        raise 'Error precompiling assets' if command.failed?
       end
 
       def add_app_files(jar_builder, options)
@@ -312,6 +328,10 @@ module TorqueBox
           ruby.evalScriptlet("$stdout = File.open('#{dev_null}', 'w')")
         end
         ruby.evalScriptlet(script)
+      end
+
+      def jruby_command(command)
+        TorqueBox::CLI::ShellCommand.run_jruby(command)
       end
 
       def app_properties(env, init)

--- a/core/lib/torquebox/cli/shell_command.rb
+++ b/core/lib/torquebox/cli/shell_command.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'English'
+
 module TorqueBox
   class CLI
     class ShellCommand
@@ -58,7 +60,7 @@ module TorqueBox
         end
 
         def run_jruby(command, options = {})
-          run(command, options.merge(prefix: jruby_prefix))
+          run(command, options.merge(:prefix => jruby_prefix))
         end
 
         def jruby_prefix
@@ -100,8 +102,8 @@ module TorqueBox
       end
 
       def run_command
-        @output    = %x[ #{prefix} #{command} ]
-        @exit_code = $?.exitstatus
+        @output    = `#{prefix} #{command}`
+        @exit_code = $CHILD_STATUS.to_i
         puts @output
       end
 

--- a/core/lib/torquebox/cli/shell_command.rb
+++ b/core/lib/torquebox/cli/shell_command.rb
@@ -1,0 +1,114 @@
+# Copyright 2016 Red Hat, Inc, and individual contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module TorqueBox
+  class CLI
+    class ShellCommand
+
+      EXIT_SUCCESS = 0
+
+      attr_reader :command, :options, :prefix, :output, :exit_code
+
+      def initialize(command, options = {})
+        @command   = command
+        @options   = options
+        @prefix    = options[:prefix]
+        @output    = nil
+        @exit_code = nil
+      end
+
+      def run
+        with_blank_rubyopt do
+          begin
+            run_command
+          rescue => e
+            print_error(e)
+          end
+        end
+        self
+      end
+
+      def succeeded?
+        run if exit_code.nil?
+        exit_code == EXIT_SUCCESS
+      end
+
+      def failed?
+        !succeeded?
+      end
+
+      def to_s
+        @output.to_s
+      end
+
+      class << self
+        def run(command, options = {})
+          new(command, options).run
+        end
+
+        def run_jruby(command, options = {})
+          run(command, options.merge(prefix: jruby_prefix))
+        end
+
+        def jruby_prefix
+          @jruby_prefix ||= [jruby_path, jruby_cli_version, '-S'].join(' ')
+        end
+
+        def jruby_path
+          @jruby_path ||= begin
+            File.join(
+              RbConfig::CONFIG['bindir'],
+              RbConfig::CONFIG['ruby_install_name']
+            )
+          end
+        end
+
+        def jruby_cli_version
+          @jruby_cli_version ||= begin
+            unless JRUBY_VERSION >= '9'
+              case RUBY_VERSION
+              when /^1\.8\./ then '--1.8'
+              when /^1\.9\./ then '--1.9'
+              when /^2\.0\./ then '--2.0'
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      def with_blank_rubyopt
+        old_rubyopt = ENV['RUBYOPT']
+        begin
+          ENV['RUBYOPT'] = ''
+          yield if block_given?
+        ensure
+          ENV['RUBYOPT'] = old_rubyopt
+        end
+      end
+
+      def run_command
+        @output    = %x[ #{prefix} #{command} ]
+        @exit_code = $?.exitstatus
+        puts @output
+      end
+
+      def print_error(error)
+        puts error.message
+        puts error.backtrace.join("\n")
+      end
+    end
+  end
+end

--- a/core/lib/torquebox/cli/shell_command.rb
+++ b/core/lib/torquebox/cli/shell_command.rb
@@ -18,16 +18,14 @@ module TorqueBox
   class CLI
     class ShellCommand
 
-      EXIT_SUCCESS = 0
-
-      attr_reader :command, :options, :prefix, :output, :exit_code
+      attr_reader :command, :options, :prefix, :output, :exit_status
 
       def initialize(command, options = {})
-        @command   = command
-        @options   = options
-        @prefix    = options[:prefix]
-        @output    = nil
-        @exit_code = nil
+        @command     = command
+        @options     = options
+        @prefix      = options[:prefix]
+        @output      = nil
+        @exit_status = nil
       end
 
       def run
@@ -42,8 +40,8 @@ module TorqueBox
       end
 
       def succeeded?
-        run if exit_code.nil?
-        exit_code == EXIT_SUCCESS
+        run if exit_status.nil?
+        exit_status.success?
       end
 
       def failed?
@@ -102,8 +100,8 @@ module TorqueBox
       end
 
       def run_command
-        @output    = `#{prefix} #{command}`
-        @exit_code = $CHILD_STATUS.to_i
+        @output      = `#{prefix} #{command}`
+        @exit_status = $CHILD_STATUS
         puts @output
       end
 

--- a/core/spec/jar_cli_spec.rb
+++ b/core/spec/jar_cli_spec.rb
@@ -51,7 +51,7 @@ describe TorqueBox::CLI::Jar do
       File.new("includeme/excludeme", "w")
       File.new("alsoexcludefoo", "w")
       TorqueBox::CLI.new(%W(jar --exclude excludeme,alsoexclude.+ -q --no-include-jruby
-                            --no-bundle-gems --name test.jar)).run
+                            --no-precompile-assets --no-bundle-gems --name test.jar)).run
       File.exist?("test.jar").should == true
       unzip("test.jar")
       File.exist?("app/excludeme").should == false
@@ -66,7 +66,7 @@ describe TorqueBox::CLI::Jar do
       File.new(".sprockets-manifest-foobarbaz.json", "w")
       File.new("baz", "w")
       TorqueBox::CLI.new(%W(jar -q --no-include-jruby
-                            --no-bundle-gems --name test.jar)).run
+                            --no-precompile-assets --no-bundle-gems --name test.jar)).run
       File.exist?("test.jar").should == true
       unzip("test.jar")
       File.exist?("app/.sprockets-manifest.json").should == true
@@ -82,7 +82,7 @@ describe TorqueBox::CLI::Jar do
       File.new(".bar", "w")
       File.new("baz", "w")
       TorqueBox::CLI.new(%W(jar -q --no-include-jruby
-                            --no-bundle-gems --name test.jar)).run
+                            --no-precompile-assets --no-bundle-gems --name test.jar)).run
       File.exist?("test.jar").should == true
       unzip("test.jar")
       File.exist?("app/.git/foo").should == false

--- a/core/spec/shell_command_spec.rb
+++ b/core/spec/shell_command_spec.rb
@@ -1,0 +1,128 @@
+# Copyright 2014 Red Hat, Inc, and individual contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe TorqueBox::CLI::ShellCommand do
+
+  let(:command)       { 'echo "test"' }
+  let(:shell_command) { TorqueBox::CLI::ShellCommand.new(command) }
+
+  describe '#run' do
+    it 'runs the command' do
+      shell_command.run
+      expect(shell_command.output.strip).to eq 'test'
+    end
+
+    it 'sets the exit code' do
+      expect {
+        shell_command.run
+      }.to change { shell_command.exit_code }.from(nil).to(0)
+    end
+
+    it 'returns a reference to the shell command object' do
+      expect(shell_command.run).to be_a TorqueBox::CLI::ShellCommand
+    end
+
+    context 'when the RUBYOPT environment variable is set' do
+      let(:command) { 'echo $RUBYOPT' }
+
+      before do
+        @old_rubyopt = ENV['RUBYOPT']
+        ENV['RUBYOPT'] = 'test'
+      end
+
+      after do
+        ENV['RUBYOPT'] = @old_rubyopt
+      end
+
+      it 'clears the RUBYOPT environment variable' do
+        shell_command.run
+        expect(shell_command.output.strip).to be_empty
+      end
+    end
+
+    context 'when the command throws an exception' do
+      before do
+        allow(shell_command).to receive(:run_command).and_raise('error')
+      end
+
+      it 'prints the error' do
+        expect(shell_command).to receive(:print_error)
+        shell_command.run
+      end
+    end
+  end
+
+  describe '#succeeded?' do
+    context 'when the command has already run' do
+      before do
+        shell_command.run
+      end
+
+      it 'does not re-run the command' do
+        expect(shell_command).to_not receive(:run)
+        shell_command.succeeded?
+      end
+    end
+
+    context 'when the command has not run yet' do
+      it 'runs the command' do
+        expect(shell_command).to receive(:run)
+        shell_command.succeeded?
+      end
+    end
+
+    context 'when the command succeeds' do
+      let(:command) { 'true' }
+
+      it 'returns true' do
+        expect(shell_command.succeeded?).to be true
+      end
+    end
+
+    context 'when the command fails' do
+      let(:command) { 'false' }
+
+      it 'returns false' do
+        expect(shell_command.succeeded?).to be false
+      end
+    end
+  end
+
+  describe '#failed?' do
+    context 'when the command succeeds' do
+      let(:command) { 'true' }
+
+      it 'returns false' do
+        expect(shell_command.failed?).to be false
+      end
+    end
+
+    context 'when the command fails' do
+      let(:command) { 'false' }
+
+      it 'returns true' do
+        expect(shell_command.failed?).to be true
+      end
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the output as a string' do
+      shell_command.run
+      expect(shell_command.to_s.strip).to eq 'test'
+    end
+  end
+end

--- a/core/spec/shell_command_spec.rb
+++ b/core/spec/shell_command_spec.rb
@@ -75,13 +75,6 @@ describe TorqueBox::CLI::ShellCommand do
       end
     end
 
-    context 'when the command has not run yet' do
-      it 'runs the command' do
-        expect(shell_command).to receive(:run)
-        shell_command.succeeded?
-      end
-    end
-
     context 'when the command succeeds' do
       let(:command) { 'true' }
 

--- a/core/spec/shell_command_spec.rb
+++ b/core/spec/shell_command_spec.rb
@@ -26,7 +26,7 @@ describe TorqueBox::CLI::ShellCommand do
     end
 
     it 'sets the exit code' do
-      expect { shell_command.run }.to change { shell_command.exit_code }.from(nil).to(0)
+      expect { shell_command.run }.to change { shell_command.exit_status }.from(nil).to(0)
     end
 
     it 'returns a reference to the shell command object' do

--- a/core/spec/shell_command_spec.rb
+++ b/core/spec/shell_command_spec.rb
@@ -26,9 +26,7 @@ describe TorqueBox::CLI::ShellCommand do
     end
 
     it 'sets the exit code' do
-      expect {
-        shell_command.run
-      }.to change { shell_command.exit_code }.from(nil).to(0)
+      expect { shell_command.run }.to change { shell_command.exit_code }.from(nil).to(0)
     end
 
     it 'returns a reference to the shell command object' do

--- a/core/spec/war_cli_spec.rb
+++ b/core/spec/war_cli_spec.rb
@@ -28,7 +28,9 @@ describe TorqueBox::CLI::War do
 
   it "sets RACK_ENV and RAILS_ENV to --env value" do
     Dir.chdir(@tmpdir) do
-      TorqueBox::CLI.new(%W(war -q --no-include-jruby --no-bundle-gems --name test.war --env foobarbaz)).run
+      TorqueBox::CLI.new(%W(war -q --no-include-jruby --no-bundle-gems
+                                --no-precompile-assets --name test.war
+                                --env foobarbaz)).run
       File.exist?("test.war").should == true
       unzip("test.war")
       jar = Dir.glob("WEB-INF/lib/app.jar").first

--- a/core/spec/war_cli_spec.rb
+++ b/core/spec/war_cli_spec.rb
@@ -29,8 +29,8 @@ describe TorqueBox::CLI::War do
   it "sets RACK_ENV and RAILS_ENV to --env value" do
     Dir.chdir(@tmpdir) do
       TorqueBox::CLI.new(%W(war -q --no-include-jruby --no-bundle-gems
-                                --no-precompile-assets --name test.war
-                                --env foobarbaz)).run
+                            --no-precompile-assets --name test.war
+                            --env foobarbaz)).run
       File.exist?("test.war").should == true
       unzip("test.war")
       jar = Dir.glob("WEB-INF/lib/app.jar").first

--- a/integration-tests/spec/archive_spec.rb
+++ b/integration-tests/spec/archive_spec.rb
@@ -29,14 +29,14 @@ if embedded_from_disk?
     end
 
     it "can execute scripts inside a basic jar" do
-      with_archive("#{apps_dir}/rack/basic", :jar) do |archive|
+      with_archive("#{apps_dir}/rack/basic", :jar, rack_options) do |archive|
         output = `java -jar #{archive} -S torquebox --version`.split('\n')
         output.first.should include(TorqueBox::VERSION)
       end
     end
 
     it "can execute scripts inside a basic war" do
-      with_archive("#{apps_dir}/rack/basic", :war) do |archive|
+      with_archive("#{apps_dir}/rack/basic", :war, rack_options) do |archive|
         FileUtils.mkdir('tmp')
         output = `java -Djava.io.tmpdir=#{@tmpdir}/tmp -jar #{archive} \
                   -S torquebox --version`.split('\n')
@@ -51,7 +51,7 @@ if embedded_from_disk?
 
     it "can execute scripts inside a basic jar with main specified" do
       app_dir = "#{apps_dir}/rack/basic"
-      with_archive(app_dir, :jar, %W(--main main.rb)) do |archive|
+      with_archive(app_dir, :jar, %W(--main main.rb) + rack_options) do |archive|
         output = `java -jar #{archive} -S torquebox --version`.split('\n')
         output.first.should include(TorqueBox::VERSION)
       end
@@ -73,6 +73,10 @@ if embedded_from_disk?
       Dir.chdir(@tmpdir) do
         yield "test.#{type}"
       end
+    end
+
+    def rack_options
+      %W(--no-precompile-assets)
     end
   end
 end

--- a/integration-tests/spec/spec_helper.rb
+++ b/integration-tests/spec/spec_helper.rb
@@ -284,7 +284,7 @@ def server_start(options)
     @stdout_thread, @stderr_thread = pump_server_streams(stdin, stdout,
                                                          stderr, error_seen)
   end
-  wait_for_boot(app_dir, 180, error_seen)
+  wait_for_boot(app_dir, 210, error_seen)
 end
 
 def jruby9k?


### PR DESCRIPTION
I attempted to use `eval_in_new_ruby` and `Bundler::CLI.start` to run the asset compilation, but no luck. I copied what TorqueBox 3.x did by shelling out the command, just wrapped it in a class. Please let me know if there are any conventions or stylings that I should change.