### PR TITLE
Fix JRuby 9.1.0.0 compatibility

### DIFF
--- a/web/ext/wunderboss-rack/org/projectodd/wunderboss/rack/RackEnvironmentHash.java
+++ b/web/ext/wunderboss-rack/org/projectodd/wunderboss/rack/RackEnvironmentHash.java
@@ -209,11 +209,6 @@ public class RackEnvironmentHash extends RubyHash {
         return super.to_s(context);
     }
     @Override
-    public IRubyObject to_s19(ThreadContext context) {
-        fillEntireHash();
-        return super.to_s19(context);
-    }
-    @Override
     public RubyHash rehash() {
         fillEntireHash();
         return super.rehash();


### PR DESCRIPTION
Method ``org.jruby.RubyHash#to_s19`` became final in 9.1.0.0.

```
ext/wunderboss-rack/org/projectodd/wunderboss/rack/RackEnvironmentHash.java:212: error: to_s19(ThreadContext) in RackEnvironmentHash cannot override to_s19(ThreadContext) in RubyHash
    public IRubyObject to_s19(ThreadContext context) {
                       ^
  overridden method is final
```

Method ``#to_s19`` is calling ``#inspect19`` in underlying ``org.jruby.RubyHash`` implementation, which is overridden in ``RackEnvironmentHash`` as well.

``#to_s19`` implementations:

1.7.x:
https://github.com/jruby/jruby/blob/1.7.25/core/src/main/java/org/jruby/RubyHash.java#L909

9.0.x.x:
https://github.com/jruby/jruby/blob/9.0.5.0/core/src/main/java/org/jruby/RubyHash.java#L905

9.1.0.0:
https://github.com/jruby/jruby/blob/9.1.0.0/core/src/main/java/org/jruby/RubyHash.java#L1000

Fixes #238 