### PR TITLE
Add option to precompile assets when building the JAR

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,7 +19,7 @@ Lint/Void:
   Enabled: false
 
 Metrics/ClassLength:
-  Max: 300
+  Max: 330
 
 Metrics/CyclomaticComplexity:
   Max: 10
@@ -28,7 +28,7 @@ Metrics/LineLength:
   Max: 115
 
 Metrics/MethodLength:
-  Max: 40
+  Max: 45
 
 Metrics/PerceivedComplexity:
   Max: 10

--- a/core/lib/torquebox/cli/jar.rb
+++ b/core/lib/torquebox/cli/jar.rb
@@ -39,6 +39,7 @@ module TorqueBox
           :destination => '.',
           :jar_name => "#{File.basename(Dir.pwd)}.jar",
           :include_jruby => true,
+          :precompile_assets => false,
           :bundle_gems => true,
           :bundle_without => %W(development test assets),
           :rackup => 'config.ru'
@@ -61,6 +62,11 @@ module TorqueBox
            :name => :include_jruby,
            :switch => '--[no-]include-jruby',
            :description => "Include JRuby in the jar (default: #{defaults[:include_jruby]})"
+         },
+         {
+           :name => :precompile_assets,
+           :switch => '--precompile-assets',
+           :description => "Precompile Rails assets in the jar (default: #{defaults[:precompile_assets]})"
          },
          {
            :name => :bundle_gems,
@@ -125,6 +131,10 @@ module TorqueBox
           add_jruby_files(jar_builder)
         end
 
+        if options[:precompile_assets]
+          precompile_assets
+        end
+
         add_app_files(jar_builder, options)
 
         if options[:bundle_gems]
@@ -179,6 +189,12 @@ module TorqueBox
                     :pattern => "/**/*",
                     :jar_prefix => "#{jar_prefix}/gems/#{gem_full_name}")
         end
+      end
+
+      def precompile_assets
+        @logger.info("Precompiling assets")
+        jruby_command("-S rake assets:precompile")
+        raise 'Error precompiling assets' unless $CHILD_STATUS.to_i == 0
       end
 
       def add_app_files(jar_builder, options)

--- a/core/lib/torquebox/cli/jar.rb
+++ b/core/lib/torquebox/cli/jar.rb
@@ -330,6 +330,27 @@ module TorqueBox
         ruby.evalScriptlet(script)
       end
 
+      def jruby_command(cmd)
+        jruby = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
+        jruby << case RUBY_VERSION
+                 when /^1\.8\./ then ' --1.8'
+                 when /^1\.9\./ then ' --1.9'
+                 when /^2\.0\./ then ' --2.0'
+                 else ''
+                 end
+        run_command("#{jruby} #{cmd}")
+      end
+
+      def run_command(cmd)
+        old_rubyopt = ENV['RUBYOPT']
+        begin
+          ENV['RUBYOPT'] = ''
+          puts `#{cmd} 2>&1`
+        ensure
+          ENV['RUBYOPT'] = old_rubyopt
+        end
+      end
+
       def app_properties(env, init)
         env_str = env.map do |key, value|
           "ENV['#{key}'] ||= '#{value}';"


### PR DESCRIPTION
The logic is copied from the `3.x` branch. It is turned off by default to prevent issues with non-rails apps. To run:

`bundle exec torquebox jar --precompile-assets`
