### PR TITLE
Handle logging of FixNum and other objects that don't implicitly map to Java Strings

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--backtrace

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,11 @@ matrix:
     - os: osx
       rvm: jruby-9.1.6.0
       jdk:
+    - os: osx
+      rvm: jruby-9.1.6.0
+      jdk:
       env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
+      osx_image: beta-xcode6.1
 #  allow_failures:
 #    - rvm: jruby-head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,10 @@ matrix:
     - os: osx
       rvm: jruby-9.1.6.0
       jdk:
-      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final" SSL_CERT_FILE=/Library/Java/Home/lib/security/cacerts
+      env:
+        - WILDFLY_VERSION="9.0.1.Final"
+        - SSL_CERT_FILE=/Library/Java/Home/lib/security/cacerts
+        - JAVA_OPTS="-Xmx1536m -XX:MaxPermSize=512M"
       osx_image: beta-xcode6.1
 #  allow_failures:
 #    - rvm: jruby-head
@@ -33,7 +36,7 @@ env:
   matrix:
     - INTEG_SUITE=spec:all
   global:
-    - JAVA_OPTS="-Xmx1536m -XX:MaxPermSize=512M"
+    - JAVA_OPTS="-Xmx1536m"
     - JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false"
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     - os: osx
       rvm: jruby-9.1.6.0
       jdk:
-      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
+      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final" SSL_CERT_FILE=/Library/Java/Home/lib/security/cacerts
       osx_image: beta-xcode6.1
 #  allow_failures:
 #    - rvm: jruby-head
@@ -45,17 +45,9 @@ cache:
 before_install:
   - gem install bundler
   - gem update bundler
-  - export
-  - echo "TRAVIS_OS_NAME is $TRAVIS_OS_NAME"
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -O https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/phantomjs/phantomjs-1.8.1-macosx.zip ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l phantomjs-1.8.1-macosx.zip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then unzip phantomjs-1.8.1-macosx.zip ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l phantomjs-1.8.1-macosx ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l phantomjs-1.8.1-macosx/bin ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l $PWD/phantomjs-1.8.1-macosx/bin ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo "PATH is $PATH" ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$PWD/phantomjs-1.8.1/bin:$PATH" ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo PATH is now $PATH ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$PWD/phantomjs-1.8.1-macosx/bin:$PATH" ; fi
   - export
 
 install: travis_retry bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,13 @@ matrix:
       rvm: jruby-9.1.6.0
       jdk: openjdk7
       env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
-    - os: linux
-      rvm: jruby-19mode
-      jdk: oraclejdk8
-      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
-    - os: linux
-      rvm: jruby-9.1.6.0
-      jdk: oraclejdk8
-      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
     - os: osx
+      jdk:
   allow_failures:
     - rvm: jruby-head
+
+jdk:
+  - oraclejdk8
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
 jdk:
   - oraclejdk8
 
+os:
+  - linux
+  - osx
+
 env:
   matrix:
     - INTEG_SUITE=spec:all

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ matrix:
       jdk: openjdk7
       env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
     - os: osx
+      rvm: jruby-9.1.6.0
       jdk:
+      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
   allow_failures:
     - rvm: jruby-head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
     - INTEG_SUITE=spec:all
   global:
     - JAVA_OPTS="-Xmx1536m -XX:MaxPermSize=512M"
+    - JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 language: ruby
 
 rvm:
-#  - jruby-19mode
+  - jruby-19mode
   - jruby-9.1.6.0
-#  - jruby-head
+  - jruby-head
 
 matrix:
   include:
-#    - os: linux
-#      rvm: jruby-19mode
-#      jdk: openjdk7
-#      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
+    - os: linux
+      rvm: jruby-19mode
+      jdk: openjdk7
+      env: WILDFLY_VERSION="9.0.1.Final"
     - os: linux
       rvm: jruby-9.1.6.0
       jdk: openjdk7
@@ -26,11 +26,11 @@ matrix:
         - SSL_CERT_FILE=/Library/Java/Home/lib/security/cacerts
         - JAVA_OPTS="-Xmx1536m -XX:MaxPermSize=512M"
       osx_image: beta-xcode6.1
-#  allow_failures:
-#    - rvm: jruby-head
+  allow_failures:
+    - rvm: jruby-head
 
-#jdk:
-#  - oraclejdk8
+jdk:
+  - oraclejdk8
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,17 @@ rvm:
 matrix:
   include:
     - rvm: jruby-19mode
-      jdk: openjdk7
       env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
     - rvm: jruby-9.1.6.0
-      jdk: openjdk7
       env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
   allow_failures:
     - rvm: jruby-head
 
-jdk:
-  - oraclejdk8
-
 os:
-  - linux
+  - linux:
+    - jdk:
+      - oraclejdk8
+      - openjdk7
   - osx
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,29 @@
 language: ruby
 
 rvm:
-  - jruby-19mode
+#  - jruby-19mode
   - jruby-9.1.6.0
-  - jruby-head
+#  - jruby-head
 
 matrix:
   include:
-    - os: linux
-      rvm: jruby-19mode
-      jdk: openjdk7
-      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
-    - os: linux
-      rvm: jruby-9.1.6.0
-      jdk: openjdk7
-      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
+#    - os: linux
+#      rvm: jruby-19mode
+#      jdk: openjdk7
+#      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
+#    - os: linux
+#      rvm: jruby-9.1.6.0
+#      jdk: openjdk7
+#      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
     - os: osx
       rvm: jruby-9.1.6.0
       jdk:
       env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
-  allow_failures:
-    - rvm: jruby-head
+#  allow_failures:
+#    - rvm: jruby-head
 
-jdk:
-  - oraclejdk8
+#jdk:
+#  - oraclejdk8
 
 env:
   matrix:
@@ -40,9 +40,16 @@ cache:
 before_install:
   - gem install bundler
   - gem update bundler
+  - echo TRAVIS_OS_NAME is $TRAVIS_OS_NAME
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -O https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/phantomjs/phantomjs-1.8.1-macosx.zip ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l phantomjs-1.8.1-macosx.zip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then unzip phantomjs-1.8.1-macosx.zip ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l phantomjs-1.8.1-macosx ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l phantomjs-1.8.1-macosx/bin ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l $PWD/phantomjs-1.8.1-macosx/bin ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo PATH is $PATH ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=$PWD/phantomjs-1.8.1/bin:$PATH ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo PATH is now $PATH ; fi
 
 install: travis_retry bundle install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ matrix:
 #      rvm: jruby-19mode
 #      jdk: openjdk7
 #      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
-#    - os: linux
-#      rvm: jruby-9.1.6.0
-#      jdk: openjdk7
-#      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
+    - os: linux
+      rvm: jruby-9.1.6.0
+      jdk: openjdk7
+      env: WILDFLY_VERSION="9.0.1.Final"
     - os: osx
       rvm: jruby-9.1.6.0
       jdk:
@@ -51,7 +51,6 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -O https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/phantomjs/phantomjs-1.8.1-macosx.zip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then unzip phantomjs-1.8.1-macosx.zip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$PWD/phantomjs-1.8.1-macosx/bin:$PATH" ; fi
-  - export
 
 install: travis_retry bundle install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,16 +44,18 @@ cache:
 before_install:
   - gem install bundler
   - gem update bundler
-  - echo TRAVIS_OS_NAME is $TRAVIS_OS_NAME
+  - export
+  - echo "TRAVIS_OS_NAME is $TRAVIS_OS_NAME"
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -O https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/phantomjs/phantomjs-1.8.1-macosx.zip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l phantomjs-1.8.1-macosx.zip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then unzip phantomjs-1.8.1-macosx.zip ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l phantomjs-1.8.1-macosx ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l phantomjs-1.8.1-macosx/bin ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ls -l $PWD/phantomjs-1.8.1-macosx/bin ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo PATH is $PATH ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=$PWD/phantomjs-1.8.1/bin:$PATH ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo "PATH is $PATH" ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="$PWD/phantomjs-1.8.1/bin:$PATH" ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then echo PATH is now $PATH ; fi
+  - export
 
 install: travis_retry bundle install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
   matrix:
     - INTEG_SUITE=spec:all
   global:
-    - JAVA_OPTS="-Xmx1536m"
+    - JAVA_OPTS="-Xmx1536m -XX:MaxPermSize=512M"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,8 @@ matrix:
 #  - oraclejdk8
 
 env:
-  matrix:
-    - INTEG_SUITE=spec:all
   global:
+    - INTEG_SUITE=spec:all
     - JAVA_OPTS="-Xmx1536m"
     - JRUBY_OPTS="--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,25 @@ rvm:
 
 matrix:
   include:
-    - rvm: jruby-19mode
+    - os: linux
+      rvm: jruby-19mode
+      jdk: openjdk7
       env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
-    - rvm: jruby-9.1.6.0
+    - os: linux
+      rvm: jruby-9.1.6.0
+      jdk: openjdk7
       env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
+    - os: linux
+      rvm: jruby-19mode
+      jdk: oraclejdk8
+      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
+    - os: linux
+      rvm: jruby-9.1.6.0
+      jdk: oraclejdk8
+      env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
+    - os: osx
   allow_failures:
     - rvm: jruby-head
-
-os:
-  - linux:
-    - jdk:
-      - oraclejdk8
-      - openjdk7
-  - osx
 
 env:
   matrix:
@@ -36,6 +42,9 @@ cache:
 before_install:
   - gem install bundler
   - gem update bundler
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then curl -O https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/phantomjs/phantomjs-1.8.1-macosx.zip ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then unzip phantomjs-1.8.1-macosx.zip ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=$PWD/phantomjs-1.8.1/bin:$PATH ; fi
 
 install: travis_retry bundle install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 
 rvm:
   - jruby-19mode
-  - jruby-9.0.5.0
+  - jruby-9.1.6.0
   - jruby-head
 
 matrix:
@@ -10,7 +10,7 @@ matrix:
     - rvm: jruby-19mode
       jdk: openjdk7
       env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
-    - rvm: jruby-9.0.5.0
+    - rvm: jruby-9.1.6.0
       jdk: openjdk7
       env: INTEG_SUITE="spec:all" WILDFLY_VERSION="9.0.1.Final"
   allow_failures:

--- a/core/lib/torquebox/logger.rb
+++ b/core/lib/torquebox/logger.rb
@@ -188,6 +188,7 @@ module TorqueBox
 
     def add(severity, *params)
       message = block_given? ? yield : params.shift
+      message = message.to_s unless message.nil?
       @logger.send(severity, message, *params)
     end
   end

--- a/core/spec/logger_spec.rb
+++ b/core/spec/logger_spec.rb
@@ -126,6 +126,10 @@ describe TorqueBox::Logger do
       logger.info(nil)
     end
 
+    it "should handle FixNum parameters" do
+      logger.info(200)
+    end
+
     it "should support the rack.errors interface" do
       logger.should respond_to(:puts)
       logger.should respond_to(:write)

--- a/core/spec/spec_helper.rb
+++ b/core/spec/spec_helper.rb
@@ -48,3 +48,7 @@ end
 def windows?
   RbConfig::CONFIG['host_os'] =~ /mswin/
 end
+
+def macos?
+  RbConfig::CONFIG['host_os'] =~ /darwin/
+end

--- a/integration-tests/spec/spec_helper.rb
+++ b/integration-tests/spec/spec_helper.rb
@@ -385,7 +385,7 @@ def server_stop
     processes =
         case
         when windows?
-          `ps -o pid --ppid #{@server_pid}`.split("\n").map(&:to_i)
+          []
         when macos?
           # macOS doesn't support the --ppid flag, but it does support outputting the parent process id
           `ps -o pid -o ppid`.split("\n")
@@ -393,7 +393,7 @@ def server_stop
             .select { | _, ppid | ppid == @server_pid }           # filter by parent process id
             .map(&:first)                                         # return only the process id
         else
-          []
+          `ps -o pid --ppid #{@server_pid}`.split("\n").map(&:to_i)
         end
     processes.each do |pid|
       kill_process(pid) if pid > 0

--- a/integration-tests/spec/spec_helper.rb
+++ b/integration-tests/spec/spec_helper.rb
@@ -295,7 +295,7 @@ end
 def popen4(*cmd)
   environment_variable_overrides = { 'RUBYLIB' => @ruby_lib, 'BUNDLE_GEMFILE' => @bundle_gemfile }
   # Use IO.popen4 for JRuby < 9.0.0.0
-  return IO.popen4(environment_variable_overrides,*cmd) unless jruby9k?
+  return IO.popen4(environment_variable_overrides, *cmd) unless jruby9k?
 
   opts = {}
   in_r, in_w = IO.pipe

--- a/integration-tests/spec/spec_helper.rb
+++ b/integration-tests/spec/spec_helper.rb
@@ -382,21 +382,19 @@ def server_stop
   end
   if @server_pid
     kill_process(@server_pid)
-    processes = case
-      when windows?
-        `ps -o pid --ppid #{@server_pid}`.split("\n").map( &:to_i )
-      when macos?
-        # macOS doesn't support the --ppid flag, but it does support outputting the parent process id
-        `ps -o pid -o ppid`.split( "\n" ).
-            # convert each line into a pair of integers - the process id and the parent process id
-            map { | line | line.strip.split( /\s+/ ).map( &:to_i ) }.
-            # filter by parent process id
-            select { | _, ppid | ppid == @server_pid }.
-            # return only the process ids
-            map( &:first )
-      else
-        []
-    end
+    processes =
+        case
+        when windows?
+          `ps -o pid --ppid #{@server_pid}`.split("\n").map(&:to_i)
+        when macos?
+          # macOS doesn't support the --ppid flag, but it does support outputting the parent process id
+          `ps -o pid -o ppid`.split("\n")
+            .map { | line | line.strip.split(/\s+/).map(&:to_i) } # convert to the process id and the parent process id
+            .select { | _, ppid | ppid == @server_pid }           # filter by parent process id
+            .map(&:first)                                         # return only the process id
+        else
+          []
+        end
     processes.each do |pid|
       kill_process(pid) if pid > 0
     end

--- a/integration-tests/spec/spec_helper.rb
+++ b/integration-tests/spec/spec_helper.rb
@@ -199,7 +199,7 @@ def uberjar(app_dir, path, main, options)
     end
     command << " --main #{main}" if main
     jar_output = `#{command} 2>&1`
-    raise "Execution of `#{command}` failed:\n#{jar_output}" unless $?.success?
+    raise "Execution of `#{command}` failed:\n#{jar_output}" unless $CHILD_STATUS.success?
     puts jar_output if ENV['DEBUG']
     wildfly_server.deploy(jarfile) if wildfly?
   end
@@ -335,7 +335,7 @@ def pump_server_streams(stdin, stdout, stderr, error_seen)
     begin
       loop do
         out_text = stdout_io.readpartial(1024)
-        out_text += "\n" unless out_text.nil? || out_text[ -1 ] == "\n"
+        out_text += "\n" unless out_text.nil? || out_text[-1] == "\n"
         STDOUT.write("STDOUT From Server: #{out_text}")
       end
     rescue EOFError, IOError
@@ -345,7 +345,7 @@ def pump_server_streams(stdin, stdout, stderr, error_seen)
     begin
       loop do
         err_text = stderr_io.readpartial(1024)
-        err_text += "\n" unless err_text.nil? || err_text[ -1 ] == "\n"
+        err_text += "\n" unless err_text.nil? || err_text[-1] == "\n"
         STDERR.write("STDERR From Server: #{err_text}")
         error_seen.set(true)
       end

--- a/integration-tests/spec/spec_helper.rb
+++ b/integration-tests/spec/spec_helper.rb
@@ -389,7 +389,7 @@ def server_stop
         when macos?
           # macOS doesn't support the --ppid flag, but it does support outputting the parent process id
           `ps -o pid -o ppid`.split("\n")
-            .map { | line | line.strip.split(/\s+/).map(&:to_i) } # convert to the process id and the parent process id
+            .map { | line | line.strip.split(/\s+/).map(&:to_i) } # convert to process id and parent process id
             .select { | _, ppid | ppid == @server_pid }           # filter by parent process id
             .map(&:first)                                         # return only the process id
         else

--- a/integration-tests/spec/spec_helper.rb
+++ b/integration-tests/spec/spec_helper.rb
@@ -199,7 +199,7 @@ def uberjar(app_dir, path, main, options)
     end
     command << " --main #{main}" if main
     r, io = IO.pipe
-    system(env_overrides, command, out: io) || raise( "Execution of `#{command}` failed" )
+    system(env_overrides, command, :out => io) || raise("Execution of `#{command}` failed")
     io.close
     puts r.read if ENV['DEBUG']
     wildfly_server.deploy(jarfile) if wildfly?
@@ -295,7 +295,7 @@ def jruby9k?
 end
 
 def env_overrides
-  {'RUBYLIB' => @ruby_lib, 'BUNDLE_GEMFILE' => @bundle_gemfile}
+  { 'RUBYLIB' => @ruby_lib, 'BUNDLE_GEMFILE' => @bundle_gemfile }
 end
 
 def popen4(*cmd)

--- a/integration-tests/spec/spec_helper.rb
+++ b/integration-tests/spec/spec_helper.rb
@@ -199,7 +199,7 @@ def uberjar(app_dir, path, main, options)
     end
     command << " --main #{main}" if main
     jar_output = `#{command} 2>&1`
-    raise jar_output unless $?.success?
+    raise "Execution of `#{command}` failed:\n#{jar_output}" unless $?.success?
     puts jar_output if ENV['DEBUG']
     wildfly_server.deploy(jarfile) if wildfly?
   end

--- a/torquebox.gemspec
+++ b/torquebox.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('builder', '~> 3.2.2')
   s.add_development_dependency('rubocop', '~> 0.25.0')
   s.add_development_dependency('addressable', '~> 2.4.0')
+  s.add_development_dependency('rack', '~> 1.6.5')
 end

--- a/torquebox.gemspec
+++ b/torquebox.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('kramdown', '~> 1.4.1')
   s.add_development_dependency('builder', '~> 3.2.2')
   s.add_development_dependency('rubocop', '~> 0.25.0')
+  s.add_development_dependency('addressable', '~> 2.4.0')
 end

--- a/torquebox.gemspec
+++ b/torquebox.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'torquebox-web', TorqueBox::VERSION
 
   s.add_development_dependency('jbundler', '~> 0.5.4')
-  s.add_development_dependency('rake', '> 12')
+  s.add_development_dependency('rake', '< 12')
   s.add_development_dependency('rake-compiler')
   s.add_development_dependency('rspec', '~> 2.99.0')
   s.add_development_dependency('torquespec', '~> 0.6')

--- a/torquebox.gemspec
+++ b/torquebox.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'torquebox-web', TorqueBox::VERSION
 
   s.add_development_dependency('jbundler', '~> 0.5.4')
-  s.add_development_dependency('rake')
+  s.add_development_dependency('rake', '> 12')
   s.add_development_dependency('rake-compiler')
   s.add_development_dependency('rspec', '~> 2.99.0')
   s.add_development_dependency('torquespec', '~> 0.6')


### PR DESCRIPTION
Also adds a regression test.

Prevents the following exception:
```
no method 'debug' for arguments (org.jruby.RubyFixnum) on Java::ChQosLogbackClassic::Logger available overloads: (java.lang.String,java.lang.Object[]) (org.slf4j.Marker,java.lang.String,java.lang.Object[])
```