### PR TITLE
Bump JRuby 9.1.5.0 -> 9.1.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -683,7 +683,7 @@
 
     <version.jboss.reloaded>0.1.2</version.jboss.reloaded>
 
-    <version.jruby>9.1.5.0</version.jruby>
+    <version.jruby>9.1.17.0</version.jruby>
     <version.snakeyaml>1.13</version.snakeyaml>
     <version.rack>1.1.0</version.rack>
 


### PR DESCRIPTION
I ran into the following JRuby issue after upgrading Ruby on Rails to 4.2.10: https://github.com/jruby/jruby/issues/4526

Using the latest JRuby with TorqueBox resolved the issue. Attached is the output after running `mvn -s support/settings.xml install`: [mvn-results.txt](https://github.com/torquebox/torquebox/files/2014643/mvn-results.txt).
