### PR TITLE
Fix compatibility with Rails 5 ActiveSupport Cache Store API

### DIFF
--- a/caching/lib/active_support/cache/torque_box_store.rb
+++ b/caching/lib/active_support/cache/torque_box_store.rb
@@ -48,7 +48,12 @@ module ActiveSupport
         options = merged_options(options)
 
         # Get the current entry
-        key = namespaced_key(name, options)
+        key = if respond_to?(:normalize_key, true)
+          normalize_key(name, options)
+        elsif respond_to?(:namespaced_key, true)
+          namespaced_key(name, options)
+        end
+
         current = read_entry(key, options)
         value = current.value.to_i
 


### PR DESCRIPTION
In Rails 5 the internal API for Cache Store subclasses changed. This fixes the problem while maintaining backwards compatibility.